### PR TITLE
Only update/install curl if not available

### DIFF
--- a/common/install-common
+++ b/common/install-common
@@ -5,5 +5,7 @@ set -e
 mkdir -p /var/lattice/setup
 cp -a /tmp/lattice-build/common/setup/* /var/lattice/setup/
 
-apt-get -y update
-apt-get -y install curl
+if [[ ! -x curl ]]; then
+  apt-get -y update
+  apt-get -y install curl
+fi


### PR DESCRIPTION
`apt-get -y update` is kinda slow to perform if not actually necessary
