### PR TITLE
Rename $LATTICE_COORDINATOR_IP to $CONSUL_SERVER_IP

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ Target Lattice using the [Lattice Cli](https://github.com/pivotal-cf-experimenta
 1. Creates a diego-cell-configuration file containing the private ip address from step 10.
         
    ```
-    echo "LATTICE_COORDINATOR_IP=10.10.1.11" > diego-cell-config
+    echo "CONSUL_SERVER_IP=10.10.1.11" > diego-cell-config
    ```
 
 1. Launch at least one instance of the diego-cell.

--- a/common/setup/bootstrap
+++ b/common/setup/bootstrap
@@ -40,7 +40,7 @@ else
     export "SYSTEM_DOMAIN=$(hostname -I | awk '{ print $2 }').xip.io"
 
     DIEGO_CELL_ID="cell-01_z"
-    echo "LATTICE_COORDINATOR_IP=127.0.0.1" >> $env_file
+    echo "CONSUL_SERVER_IP=127.0.0.1" >> $env_file
 fi
 
 echo "SYSTEM_DOMAIN=$SYSTEM_DOMAIN" >> $env_file

--- a/diego-cell/upstart/consul.conf
+++ b/diego-cell/upstart/consul.conf
@@ -13,7 +13,7 @@ script
     echo "UPSTART: Trying to start consul - `date --rfc-3339=ns`"
     export $(cat /var/lattice/setup/lattice-environment)
 
-    consul agent -config-file /var/lattice/config/consul.json -data-dir /tmp/consul -join $LATTICE_COORDINATOR_IP
+    consul agent -config-file /var/lattice/config/consul.json -data-dir /tmp/consul -join $CONSUL_SERVER_IP
 end script
 
 post-stop exec sleep 5


### PR DESCRIPTION
I think technically the `$LATTICE_COORDINATOR_IP` variable is really to allow diego cells' consul client to connect with the consul server; which might (currently is) running on the coordinator VM/job. Perhaps consider renaming it to `CONSUL_SERVER_IP` in preparation for allowing reuse of an existing consul server cluster and/or deployment of consul server outside of the coordinator job VM.
