### PR TITLE
dyslexics of the world, untie!

### DIFF
--- a/ltc/app_runner/command_factory/app_runner_command_factory.go
+++ b/ltc/app_runner/command_factory/app_runner_command_factory.go
@@ -24,7 +24,7 @@ import (
 
 const (
 	InvalidPortErrorMessage          = "Invalid port specified. Ports must be a comma-delimited list of integers between 0-65535."
-	MalformedRouteErrorMessage       = "Malformed route. Routes must be of the format route:port"
+	MalformedRouteErrorMessage       = "Malformed route. Routes must be of the format port:route"
 	MustSetMonitoredPortErrorMessage = "Must set monitored-port when specifying multiple exposed ports unless --no-monitor is set."
 )
 


### PR DESCRIPTION
the version of ltc that's running on my mac needs routes to be updated in the form of port:route, the help text says route:port. Looks like that's the intent in updated file as well, though I'm no go-ologist. 
