### PR TITLE
Add Elastic IP capability to the terraform script so that you can restart your AWS cluster of cells and lattice-coordinator

### DIFF
--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,5 +1,5 @@
 output "lattice_target" {
-    value = "${aws_eip.public_ip}.xip.io"
+    value = "${aws_eip.lb.public_ip}.xip.io"
 }
 
 output "lattice_username" {

--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,5 +1,5 @@
 output "lattice_target" {
-    value = "${aws_instance.lattice-coordinator.public_ip}.xip.io"
+    value = "${aws_eip.public_ip}.xip.io"
 }
 
 output "lattice_username" {

--- a/terraform/aws/resources.tf
+++ b/terraform/aws/resources.tf
@@ -164,7 +164,7 @@ resource "aws_instance" "lattice-cell" {
         script = "${path.module}/../remote-scripts/install-lattice-cell"
     }
     resource "aws_eip" "lb" {
-        instance = "${aws_instance.lattice-coordinator}"
+        instance = "${aws_instance.lattice-coordinator.id}"
         vpc = true
 }
 

--- a/terraform/aws/resources.tf
+++ b/terraform/aws/resources.tf
@@ -54,6 +54,9 @@ resource "aws_security_group" "lattice-network" {
     }
 }
 
+resource "aws_eip" "lb" {
+}
+
 resource "aws_instance" "lattice-coordinator" {
     ami = "${lookup(var.aws_image, var.aws_region)}"
     instance_type = "${var.aws_instance_type_coordinator}"
@@ -163,9 +166,4 @@ resource "aws_instance" "lattice-cell" {
     provisioner "remote-exec" {
         script = "${path.module}/../remote-scripts/install-lattice-cell"
     }
-    resource "aws_eip" "lb" {
-        instance = "${aws_instance.lattice-coordinator.id}"
-        vpc = true
-}
-
 }

--- a/terraform/aws/resources.tf
+++ b/terraform/aws/resources.tf
@@ -55,6 +55,7 @@ resource "aws_security_group" "lattice-network" {
 }
 
 resource "aws_eip" "lb" {
+    instance = "${aws_instance.lattice-coordinator.id}"
 }
 
 resource "aws_instance" "lattice-coordinator" {
@@ -103,7 +104,7 @@ resource "aws_instance" "lattice-coordinator" {
             "sudo sh -c 'echo \"LATTICE_USERNAME=${var.lattice_username}\" > /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"LATTICE_PASSWORD=${var.lattice_password}\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"CONSUL_SERVER_IP=${aws_instance.lattice-coordinator.private_ip}\" >> /var/lattice/setup/lattice-environment'",
-            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.lb.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
+            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_instance.lattice-coordinator.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
         ]
     }
 
@@ -157,7 +158,7 @@ resource "aws_instance" "lattice-cell" {
         inline = [
             "sudo mkdir -p /var/lattice/setup",
             "sudo sh -c 'echo \"CONSUL_SERVER_IP=${aws_instance.lattice-coordinator.private_ip}\" >> /var/lattice/setup/lattice-environment'",
-            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.lb.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
+            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_instance.lattice-coordinator.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"LATTICE_CELL_ID=lattice-cell-${count.index}\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"GARDEN_EXTERNAL_IP=$(hostname -I | awk '\"'\"'{ print $1 }'\"'\"')\" >> /var/lattice/setup/lattice-environment'",
         ]

--- a/terraform/aws/resources.tf
+++ b/terraform/aws/resources.tf
@@ -100,7 +100,7 @@ resource "aws_instance" "lattice-coordinator" {
             "sudo sh -c 'echo \"LATTICE_USERNAME=${var.lattice_username}\" > /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"LATTICE_PASSWORD=${var.lattice_password}\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"CONSUL_SERVER_IP=${aws_instance.lattice-coordinator.private_ip}\" >> /var/lattice/setup/lattice-environment'",
-            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
+            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.lb.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
         ]
     }
 
@@ -154,7 +154,7 @@ resource "aws_instance" "lattice-cell" {
         inline = [
             "sudo mkdir -p /var/lattice/setup",
             "sudo sh -c 'echo \"CONSUL_SERVER_IP=${aws_instance.lattice-coordinator.private_ip}\" >> /var/lattice/setup/lattice-environment'",
-            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
+            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.lb.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"LATTICE_CELL_ID=lattice-cell-${count.index}\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"GARDEN_EXTERNAL_IP=$(hostname -I | awk '\"'\"'{ print $1 }'\"'\"')\" >> /var/lattice/setup/lattice-environment'",
         ]

--- a/terraform/aws/resources.tf
+++ b/terraform/aws/resources.tf
@@ -100,7 +100,7 @@ resource "aws_instance" "lattice-coordinator" {
             "sudo sh -c 'echo \"LATTICE_USERNAME=${var.lattice_username}\" > /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"LATTICE_PASSWORD=${var.lattice_password}\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"CONSUL_SERVER_IP=${aws_instance.lattice-coordinator.private_ip}\" >> /var/lattice/setup/lattice-environment'",
-            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_instance.lattice-coordinator.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
+            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
         ]
     }
 
@@ -154,7 +154,7 @@ resource "aws_instance" "lattice-cell" {
         inline = [
             "sudo mkdir -p /var/lattice/setup",
             "sudo sh -c 'echo \"CONSUL_SERVER_IP=${aws_instance.lattice-coordinator.private_ip}\" >> /var/lattice/setup/lattice-environment'",
-            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_instance.lattice-coordinator.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
+            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"LATTICE_CELL_ID=lattice-cell-${count.index}\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"GARDEN_EXTERNAL_IP=$(hostname -I | awk '\"'\"'{ print $1 }'\"'\"')\" >> /var/lattice/setup/lattice-environment'",
         ]

--- a/terraform/aws/resources.tf
+++ b/terraform/aws/resources.tf
@@ -163,5 +163,9 @@ resource "aws_instance" "lattice-cell" {
     provisioner "remote-exec" {
         script = "${path.module}/../remote-scripts/install-lattice-cell"
     }
+    resource "aws_eip" "lb" {
+        instance = "${aws_instance.lattice-coordinator}"
+        vpc = true
+}
 
 }


### PR DESCRIPTION
added a new resource which will make the aws_instance.lattice-coordinator.public_id static so you can shutdown and restart the cluster and then reconnect from the ltc cli without changing the config. 
resource "aws_eip" "lb" {
    instance = "${aws_instance.lattice-coordinator.id}"
}
