### PR TITLE
Digital Ocean terraform templates refer to SSH fingerprint instead of SSH key ID

### DIFF
--- a/terraform/digitalocean/README.md
+++ b/terraform/digitalocean/README.md
@@ -25,7 +25,7 @@ Here are some step-by-step instructions for configuring a Lattice cluster via Te
 The available variables that can be configured are:
 
 * `do_token`: Digital Ocean API token
-* `do_ssh_public_key_fingerprint`: SSH public key fingerprint
+* `do_ssh_public_key_id`: SSH public key id. Key ID of your uploaded SSH key.
 * `do_ssh_private_key_file`: Path to the SSH private key file
 * `do_region`: The DO region to operate under (default `nyc2`)
 * `do_image`: The droplet image ID or slug to base the launched instances (default `ubuntu-14-04-x64`)
@@ -38,16 +38,11 @@ The available variables that can be configured are:
 Refer to the [Terraform DigitalOcean (DO) provider](https://www.terraform.io/docs/providers/do/index.html)
 documentation for more details about how to configure the proper credentials.
 
-#### Generating the SSH public key fingerprint 
+### Getting your SSH Key ID
 
-You can generate the SSH public key fingerprint from your public key via (e.g.)
+You can get the key ID by executing an API call against the Digital Ocean API. More info here
 
-```
-ssh-keygen -lf ~/.ssh/id_rsa.pub
-2048 aa:bb:cc:dd:ee:ff:aa:bb:cc:dd:ee:ff:aa:bb:cc:dd foo@bar.com (RSA)
-```
-
-The fingerprint is the second column in the output (`aa:bb...`)
+https://developers.digitalocean.com/documentation/v1/ssh-keys/
 
 ### Deploy
 

--- a/terraform/digitalocean/example/lattice.digitalocean.tf
+++ b/terraform/digitalocean/example/lattice.digitalocean.tf
@@ -4,10 +4,10 @@ module "lattice-digitalocean" {
     # Digital Ocean API token
     do_token = "<CHANGE-ME>"
 
-    # SSH public key fingerprint
-    do_ssh_public_key_fingerprint = "<CHANGE-ME>"
+    # SSH public key id. Get the key ID from https://developers.digitalocean.com/documentation/v1/ssh-keys/
+    do_ssh_public_key_id = "<CHANGE-ME>"
 
-    # Path to the SSH private key file
+    # Path to the SSH private key file. This needs to match the public key id defined above
     do_ssh_private_key_file = "<CHANGE-ME>"
 
     # The number of Lattice Cells to launch

--- a/terraform/digitalocean/resources.tf
+++ b/terraform/digitalocean/resources.tf
@@ -4,7 +4,7 @@ resource "digitalocean_droplet" "lattice-brain" {
     image    = "${var.do_image}"
     size     = "${var.do_size_brain}"
     ssh_keys = [
-      "${var.do_ssh_public_key_fingerprint}",
+      "${var.do_ssh_public_key_id}",
     ]
     private_networking = true
 
@@ -57,7 +57,7 @@ resource "digitalocean_droplet" "lattice-cell" {
     image    = "${var.do_image}"
     size     = "${var.do_size_cell}"
     ssh_keys = [
-      "${var.do_ssh_public_key_fingerprint}",
+      "${var.do_ssh_public_key_id}",
     ]
     private_networking = true
 

--- a/terraform/digitalocean/variables.tf
+++ b/terraform/digitalocean/variables.tf
@@ -2,8 +2,8 @@ variable "do_token" {
     description = "Digital Ocean API token."
 }
 
-variable "do_ssh_public_key_fingerprint" {
-    description = "SSH public key fingerprint."
+variable "do_ssh_public_key_id" {
+    description = "SSH public key id."
 }
 
 variable "do_ssh_private_key_file" {


### PR DESCRIPTION
Terraform requires a Digital Ocean SSH Key ID e.g. one that is retrieved from

https://developers.digitalocean.com/documentation/v1/ssh-keys/

It's an integer. This pull renames the variable and also corrects the documentation.
