### PR TITLE
Add AWS Elastic IP capability such that you can restart the cluster

### DIFF
--- a/terraform/aws/outputs.tf
+++ b/terraform/aws/outputs.tf
@@ -1,5 +1,5 @@
 output "lattice_target" {
-    value = "${aws_instance.lattice-brain.public_ip}.xip.io"
+    value = "${aws_eip.ip.public_ip}.xip.io"
 }
 
 output "lattice_username" {


### PR DESCRIPTION
basically added a new resource call aws_eip.lb to create a new elastic IP and assign to the lattice brain instance. Because of the circular dependency and the order that terraform creates resources, I had to move the provisioner for the public IP into the EIP resource itself and restart the VM to make sure the changes took effect. This is a bit of a hack but works well.

thanks
