### PR TITLE
ltc command flags should have short versions

### DIFF
--- a/ltc/app_runner/command_factory/app_runner_command_factory.go
+++ b/ltc/app_runner/command_factory/app_runner_command_factory.go
@@ -92,7 +92,7 @@ func (factory *AppRunnerCommandFactory) MakeCreateAppCommand() cli.Command {
 			Value: &cli.StringSlice{},
 		},
 		cli.IntFlag{
-			Name:  "cpu-weight",
+			Name:  "cpu-weight, c",
 			Usage: "Relative CPU weight for the container (valid values: 1-100)",
 			Value: 100,
 		},
@@ -111,16 +111,16 @@ func (factory *AppRunnerCommandFactory) MakeCreateAppCommand() cli.Command {
 			Usage: "Ports to expose on the container",
 		},
 		cli.IntFlag{
-			Name:  "monitored-port",
+			Name:  "monitored-port, M", // -m is already used for memory
 			Usage: "Selects which port is used to healthcheck the app. Required for multiple exposed ports",
 		},
 		cli.StringFlag{
-			Name: "routes",
+			Name: "routes, R", // -r is already used for root user
 			Usage: "Route mappings to exposed ports as follows:\n\t\t" +
 				"--routes=80:web,8080:api will route web to 80 and api to 8080",
 		},
 		cli.IntFlag{
-			Name:  "instances",
+			Name:  "instances, i",
 			Usage: "Number of application instances to spawn on launch",
 			Value: 1,
 		},
@@ -133,7 +133,7 @@ func (factory *AppRunnerCommandFactory) MakeCreateAppCommand() cli.Command {
 			Usage: "Registers no routes for the app",
 		},
 		cli.DurationFlag{
-			Name:  "timeout",
+			Name:  "timeout, t",
 			Usage: "Polling timeout for app to start",
 			Value: DefaultPollingTimeout,
 		},
@@ -184,7 +184,7 @@ func (factory *AppRunnerCommandFactory) MakeCreateLrpCommand() cli.Command {
 func (factory *AppRunnerCommandFactory) MakeScaleAppCommand() cli.Command {
 	var scaleFlags = []cli.Flag{
 		cli.DurationFlag{
-			Name:  "timeout",
+			Name:  "timeout, t",
 			Usage: "Polling timeout for app to scale",
 			Value: DefaultPollingTimeout,
 		},

--- a/ltc/integration_test/command_factory/integration_test_command_factory.go
+++ b/ltc/integration_test/command_factory/integration_test_command_factory.go
@@ -19,7 +19,7 @@ func (factory *IntegrationTestCommandFactory) MakeIntegrationTestCommand() cli.C
 
 	testFlags := []cli.Flag{
 		cli.DurationFlag{
-			Name:  "timeout",
+			Name:  "timeout, t",
 			Usage: "Duration of time tests will wait for lattice to respond",
 			Value: time.Minute * 2,
 		},

--- a/ltc/logs/command_factory/logs_command_factory.go
+++ b/ltc/logs/command_factory/logs_command_factory.go
@@ -42,7 +42,7 @@ func (factory *logsCommandFactory) MakeLogsCommand() cli.Command {
 func (factory *logsCommandFactory) MakeDebugLogsCommand() cli.Command {
 	var debugLogsFlags = []cli.Flag{
 		cli.BoolFlag{
-			Name:  "raw",
+			Name:  "raw, r",
 			Usage: "Removes pretty formatting",
 		},
 	}
@@ -60,7 +60,7 @@ func (factory *logsCommandFactory) tailLogs(context *cli.Context) {
 	appGuid := context.Args().First()
 
 	if appGuid == "" {
-		factory.ui.SayIncorrectUsage("")
+		factory.ui.SayIncorrectUsage("APP_NAME required")
 		return
 	}
 

--- a/ltc/logs/command_factory/logs_command_factory_test.go
+++ b/ltc/logs/command_factory/logs_command_factory_test.go
@@ -61,8 +61,7 @@ var _ = Describe("CommandFactory", func() {
 		It("handles invalid appguids", func() {
 			test_helpers.ExecuteCommandWithArgs(logsCommand, []string{})
 
-			Expect(outputBuffer).To(test_helpers.Say("Incorrect Usage"))
-			Expect(fakeTailedLogsOutputter.OutputTailedLogsCallCount()).To(Equal(0))
+			Expect(outputBuffer).To(test_helpers.SayIncorrectUsage())
 		})
 
 		It("handles non existent application", func() {


### PR DESCRIPTION
Some ltc sub-command's options now have short version.

Example output for ltc create command. 
Before fix:

```
# ltc create -h
OPTIONS:
   --working-dir, -w                            Working directory for container (overrides Docker metadata)
   --run-as-root, -r                            Runs in the context of the root user
   --env, -e [--env option --env option]        Environment variables (can be passed multiple times)
   --cpu-weight "100"                           Relative CPU weight for the container (valid values: 1-100)
   --memory-mb, -m "128"                        Memory limit for container in MB
   --disk-mb, -d "1024"                         Disk limit for container in MB
   --ports, -p                                  Ports to expose on the container
   --monitored-port "0"                         Selects which port is used to healthcheck the app. Required for multiple exposed ports
   --routes                                     Route mappings to exposed ports as follows:
                                                        --routes=80:web,8080:api will route web to 80 and api to 8080
   --instances "1"                              Number of application instances to spawn on launch
   --no-monitor                                 Disables healthchecking for the app
   --no-routes                                  Registers no routes for the app
   --timeout "2m0s"                             Polling timeout for app to start
```

After fix:

```
OPTIONS:
   --working-dir, -w                            Working directory for container (overrides Docker metadata)
   --run-as-root, -r                            Runs in the context of the root user
   --env, -e [--env option --env option]        Environment variables (can be passed multiple times)
   --cpu-weight, -c "100"                       Relative CPU weight for the container (valid values: 1-100)
   --memory-mb, -m "128"                        Memory limit for container in MB
   --disk-mb, -d "1024"                         Disk limit for container in MB
   --ports, -p                                  Ports to expose on the container
   --monitored-port, -M "0"                     Selects which port is used to healthcheck the app. Required for multiple exposed ports
   --routes, -R                                 Route mappings to exposed ports as follows:
                                                        --routes=80:web,8080:api will route web to 80 and api to 8080
   --instances, -i "1"                          Number of application instances to spawn on launch
   --no-monitor                                 Disables healthchecking for the app
   --no-routes                                  Registers no routes for the app
   --timeout, -t "2m0s"                         Polling timeout for app to start
```

Similarly for other commands like `scale` `debug-logs` `test`

ltc logs now reports Incorrect Usage like other sub-commands.
Before fix:

```
# ltc logs
Incorrect Usage
```

After fix:

```
# ltc logs
Incorrect Usage: APP_NAME required
```

[PS:Original author is @savitaashture ]
[#93138244]
