### PR TITLE
Add in files from lattice-website, add frontmatter headers to lattice docs

### DIFF
--- a/docs/development-readme.md
+++ b/docs/development-readme.md
@@ -1,4 +1,11 @@
-#Lattice Development Readme
+---
+title: Lattice Development
+weight: 9
+doc_subnav: true
+
+---
+
+#Lattice Development
 
 ##Cluster Development
 

--- a/docs/dnsmasq-readme.md
+++ b/docs/dnsmasq-readme.md
@@ -1,9 +1,11 @@
+<!--
 ---
 title: DNSMasq Configuration
 weight: 8
 doc_subnav: true
 
 ---
+-->
 
 # DNSMasq Configuration on OSX
 

--- a/docs/dnsmasq-readme.md
+++ b/docs/dnsmasq-readme.md
@@ -1,3 +1,10 @@
+---
+title: DNSMasq Configuration
+weight: 8
+doc_subnav: true
+
+---
+
 # DNSMasq Configuration on OSX
 
 Many Lattice services run over HTTP. Via the [Gorouter](https://github.com/cloudfoundry/gorouter), they share the same IP address. They are distinguished based on which hostname they've been accessed by. That's why many Lattice examples require the use of `.xip.io` instead of the raw IP address. That way, the client correctly communicates the domain name to the service regardless of how many services share that IP address.
@@ -9,14 +16,17 @@ After following these instructions, wherever you see `servicename.IP-ADDRESS.xip
 ## Installation 
 
 - Use Homebrew to install `dnsmasq`
+
 ```bash
 # Update your homebrew installation
 $ brew up
 # Install dnsmasq
 $ brew install dnsmasq
 ```
+
 - Use the commands provided by `brew info dnsmasq` to configure and start the service:  
   * As of dnsmasq v2.72, `brew info dnsmasq` returned:
+
 ```bash
 $ brew info dnsmasq
 dnsmasq: stable 2.72 (bottled)
@@ -42,10 +52,13 @@ Then to load dnsmasq now:
 
 ### Set up dnsmasq to resolve lattice.dev
 - Using your favorite text editor, append the following line to `/usr/local/etc/dnsmasq.conf`. Make sure to replace `<LATTICE_SYSTEM_IP>` with your Lattice target IP address. 
+
 ```bash
 address=/lattice.dev/<LATTICE_SYSTEM_IP> # i.e., 192.168.11.11
 ```
+
 - Restart the dnsmasq service
+
 ```bash
 $ sudo launchctl stop homebrew.mxcl.dnsmasq
 $ sudo launchctl start homebrew.mxcl.dnsmasq
@@ -53,10 +66,13 @@ $ sudo launchctl start homebrew.mxcl.dnsmasq
 
 ### Configure your workstation to use the dnsmasq resolver for lattice.dev
 - Create `/etc/resolver` folder
+
 ```bash
 $ sudo mkdir /etc/resolver
 ```
+
 - Create a file that defines the resolver for `lattice.dev`
+
 ```bash
 $ sudo tee /etc/resolver/lattice.dev >/dev/null <<EOF
 nameserver 127.0.0.1
@@ -65,12 +81,14 @@ EOF
 
 ## Starting Lattice cluster with alternate name
 - Set `LATTICE_SYSTEM_DOMAIN` environment variable during `vagrant up`:
+
 ```
 LATTICE_SYSTEM_DOMAIN=lattice.dev vagrant up --provider=<PROVIDER> 
 ```
 
 ### Validating your dnsmasq setup
 Here's how you can prove that you're set up to redirect requests for the lattice.dev domain, as well as make sure that regular DNS resolution has not been affected.
+
 ```bash
 $ host www.lattice.dev 127.0.0.1
 Using domain server:

--- a/docs/dnsmasq-readme.md
+++ b/docs/dnsmasq-readme.md
@@ -1,11 +1,9 @@
-<!--
 ---
 title: DNSMasq Configuration
 weight: 8
 doc_subnav: true
 
 ---
--->
 
 # DNSMasq Configuration on OSX
 

--- a/docs/docker-image-examples.md
+++ b/docs/docker-image-examples.md
@@ -1,0 +1,50 @@
+---
+title: Docker Image Examples
+weight: 6
+doc_subnav: true
+---
+
+# Docker Image Examples
+
+Lattice supports docker images. Lattice containers currently use ephemeral disk and therefore are only suitable for running workloads that can have persistent disk reset on restart events, which works fine for many development and testing scenarios. After a container referencing a docker image with well-known ports is running, use the `ltc status APPNAME` command to see the port mapping. See the [troubleshooting](../troubleshooting) docs if necessary.
+
+### Redis
+`ltc create redis redis -r`
+
+### Rabbit
+`ltc create rabbit rabbitmq -r`
+
+### MySQL
+`ltc create mysql mysql -r -e MYSQL_ROOT_PASSWORD=somesecret`
+
+### Postgres
+`ltc create postgres postgres -r --no-monitor -e POSTGRES_PASSWORD=somesecret`
+
+note: if you do not use --no-monitor, you continually see the log message:
+`LOG:  incomplete startup packet`
+
+### Mongo
+`ltc create mongo mongo -r -e LC_ALL=C -- /entrypoint.sh mongod --smallfiles`
+
+### Neo4J
+`ltc create neo4j tpires/neo4j -r -m 512`
+
+It may take some time for the container to load such that initial the ltc create operation times out, you can monitor the status with `ltc status neo4j -r 2s` or `ltc debug-logs | veritas chug` to monitor the progress.
+
+### Ubuntu
+`ltc create ubuntu library/ubuntu -- nc -l 8080`
+
+### Nginx
+`ltc start nginx library/nginx -p 80 -r`
+
+### Spring Cloud Config Server
+`ltc create --run-as-root configserver springcloud/configserver`
+
+If you want to register with Eureka add an env var:
+`ltc create --env EUREKA_SERVICE_URL=http://eureka.192.168.11.11.xip.io --run-as-root configserver springcloud/configserver`
+
+### Spring Cloud Eureka Server
+`ltc create --run-as-root eureka springcloud/eureka`
+
+### Spring Cloud Clients
+`ltc create --run-as-root --env CONFIG_SERVER_URL=http://configserver.192.168.11.11.xip.io --env EUREKA_SERVICE_URL=http://eureka.192.168.11.11.xip.io myapp mygroup/myapp`

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,141 @@
+---
+title: Getting Started
+weight: 2
+doc_subnav: true
+---
+
+# Getting Started
+
+You can run Lattice easily on your laptop with a [Vagrant VM](https://github.com/cloudfoundry-incubator/lattice#local-deployment) or deploy a [cluster of machines](https://github.com/cloudfoundry-incubator/lattice#clustered-deployment) with [AWS](https://github.com/cloudfoundry-incubator/lattice/blob/master/terraform/aws/README.md), [Digital Ocean](https://github.com/cloudfoundry-incubator/lattice/blob/master/terraform/digitalocean/README.md) or [Google Cloud](https://github.com/cloudfoundry-incubator/lattice/blob/master/terraform/google/README.md).
+
+This tutorial walks you through the Vagrant VM flow and using Lattice to start applications based on a docker image, scale them up and down and retrieve logs.
+
+## Pre-Requisites for the Vagrant VM
+
+- [Vagrant](https://www.vagrantup.com)
+- [VirtualBox](https://www.virtualbox.org) or [VMware Fusion](http://www.vmware.com/products/fusion) (version 7 or later)
+- [git](https://git-scm.com)
+
+## Starting the Lattice Vagrant VM
+
+First, clone the Lattice repository:
+
+    git clone https://github.com/cloudfoundry-incubator/lattice.git
+    cd lattice
+    git checkout <%= version %>
+
+Then bring up the Vagrant box:
+
+**Virtualbox**:
+
+    vagrant up --provider virtualbox
+
+**VMware Fusion**:
+
+    vagrant up --provider vmware_fusion
+
+The VM should download and start.
+
+> By default the Lattice VM will be reachable at `192.168.11.11`. You can set the `LATTICE_SYSTEM_IP` environment variable when running `vagrant up` to modify this.  
+
+> If you are trying to run both the VirtualBox and VMWare providers on the same machine, you'll need to run them on different private networks (subnets) that do not conflict.
+
+> Learn more about deploying Lattice at the GitHub [README](https://github.com/cloudfoundry-incubator/lattice/tree/<%= version %>)
+
+## Fetching `ltc` - the Lattice CLI
+
+Visit the [GitHub Releases](https://github.com/cloudfoundry-incubator/lattice/releases) page to fetch the latest version of the CLI.  Make sure its on your `PATH`.
+
+Alternatively you can use these installation scripts.  They assume `$HOME/bin` is on your `PATH`.
+
+For Mac:
+
+    mkdir -p $HOME/bin
+    wget https://lattice.s3.amazonaws.com/releases/<%= version %>/darwin-amd64/ltc -O $HOME/bin/ltc
+    chmod +x $HOME/bin/ltc
+
+For Linux:
+
+    mkdir -p $HOME/bin
+    wget https://lattice.s3.amazonaws.com/releases/<%= version %>/linux-amd64/ltc -O $HOME/bin/ltc
+    chmod +x $HOME/bin/ltc
+
+Further instructions can be found [here](https://github.com/cloudfoundry-incubator/lattice/tree/master/ltc).
+
+## Targetting Lattice
+
+You need to tell `ltc` how to connect to your Lattice deployment.  The target domain should be printed out when you `vagrant up`.  If you have not changed the default settings you can:
+
+    ltc target 192.168.11.11.xip.io
+
+## Launching and Routing to a Dockerimage
+
+We have a simple Go-based demo web application hosted on the Docker registry at [`cloudfoundry/lattice-app`](https://registry.hub.docker.com/cloudfoundry/lattice-app).  You can launch this image by running:
+
+    ltc create lattice-app cloudfoundry/lattice-app
+
+Once the application is running, `ltc` will emit the route you can use to access the application:
+
+    Starting App: lattice-app...
+    lattice-app is now running.
+    http://lattice-app.192.168.11.11.xip.io
+
+You should be able to visit `lattice-app.192.168.11.11.xip.io` in your browser.
+
+The `lattice-app` has three endpoints:
+
+- `/` is a pretty landing page that includes the instance's index and uptime
+- `/env` prints out the instance's environment
+- `/exit` causes the instance to crash
+
+## Tailing Logs
+
+To stream logs from your running `lattice-app`:
+
+    ltc logs lattice-app
+
+Visiting `lattice-app.192.168.11.11.xip.io` will emit log messages that should be visible in your terminal.
+
+## Listing Applications
+
+To view a list of all running applications:
+
+    ltc list
+
+## Scaling Applications
+
+To scale `lattice-app` to 3 instances:
+
+    ltc scale lattice-app 3
+
+Now `ltc list` should show that `3/3` instances are running and `ltc logs lattice-app` will aggregate logs from all three instances.
+
+Visiting `lattice-app.192.168.11.11.xip.io` should cycle through the different instances that are running.  Each instance will have a unique index.
+
+## Getting Application Details
+
+To view detailed information about your running instances:
+
+    ltc status lattice-app
+
+## Visualizing Containers
+
+To visualize the distribution of containers on your lattice cluster:
+
+    ltc visualize
+
+If you deploy a cluster of Lattice cells `ltc visualize` will show you the distribution of instances across the cluster.
+
+## Crash Recovery Demo
+
+Visit `lattice-app.192.168.11.11.xip.io/exit`
+
+This will cause one of the `lattice-app` instances to exit.  Lattice will immediately restart the instance.
+
+If you cause an instance of `lattice-app` to exit repeatedly Lattice will eventually start applying a backoff policy and restart the instance only after increasing intervals of time (30s, 60s, etc...)
+
+## Where to go from here:
+
+- push your own Dockerimage
+- learn more about [`ltc`](/docs/ltc.html)
+- learn more about the RESTful [`Lattice API`](/docs/lattice-api.html).  This allows you to launch one off tasks in addition to long running processes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,132 @@
+---
+title: Lattice FAQ
+weight: 1
+doc_subnav: true
+---
+
+# Lattice FAQ
+
+## What is Lattice?
+
+Lattice is an open source project for running containerized workloads on a cluster.  A Lattice cluster is comprised of a number of Lattice Cells (VMs that run containers) and a 'Brain' that monitors the Cells.
+
+Lattice includes built-in http load-balancing, a cluster scheduler, log aggregation with log streaming and health management.
+
+Lattice containers are described as long-running processes or temporary tasks. Lattice includes support for Linux Containers expressed either as Docker Images or by composing applications as binary code on top of a root file system. Lattice's container pluggability will enable other backends such as [Windows](https://www.youtube.com/watch?v=S4U_YyzC5z4) or [Rocket](http://blog.pivotal.io/cloud-foundry-pivotal/news-2/launching-rockets-collaborating-on-next-level-linux-containers) in the future.
+
+All this functionality leverages components of [Cloud Foundry](https://github.com/cloudfoundry). The new parts in Lattice are the CLI to interact with the component APIs and the installers.
+
+## Why did we create Lattice?
+
+We wanted to be able to leverage components of Cloud Foundry independently to demonstrate the capabilities and facilitate more rapid experimentation. We believe these components are already useful in their own right, but will also improve with more wide adoption and exposure.
+
+We also have a strong opinions on the developer and operator experience for scalable applications that we hoped to express with Lattice. Our foundational principles are:
+
+- **Simple**: you should be able to get started in minutes.
+- **Comprehensive**: include capabilities commonly required for scalable applications.
+- **Extensible**: you should be able to use it how you like, adding and taking away things.
+
+
+Lattice lives up to these principles.
+
+- **Simple**: a [small Vagrant VM](https://github.com/cloudfoundry-incubator/lattice#vagrant) easily fits on most laptops. [Terraform scripts](https://github.com/pivotal-cf-experimental/lattice#terraform-deployment) enable you to easily start a Lattice cluster on your cloud of choice. Very few new concepts are required to use Lattice and you can [get started in minutes](/docs/getting-started.html).
+- **Comprehensive**: Lattice currently includes load balancing, aggregated logs, health management, and cluster scheduling.
+- **Extensible**: Docker is very popular and we are supporting Docker Images. We also believe in a [pluggable container backend](https://github.com/cloudfoundry-incubator/garden) so there are options to support [Windows](https://www.youtube.com/watch?v=S4U_YyzC5z4), [Rocket](http://blog.pivotal.io/cloud-foundry-pivotal/news-2/launching-rockets-collaborating-on-next-level-linux-containers) or other backends.
+
+## How do I deploy Lattice?
+
+You can run Lattice easily on your laptop with a [Vagrant VM](https://github.com/cloudfoundry-incubator/lattice#local-deployment) or deploy a [cluster of machines](https://github.com/cloudfoundry-incubator/lattice#clustered-deployment) with [AWS](https://github.com/cloudfoundry-incubator/lattice/blob/master/terraform/aws/README.md), [Digital Ocean](https://github.com/cloudfoundry-incubator/lattice/blob/master/terraform/digitalocean/README.md) or [Google Cloud](https://github.com/cloudfoundry-incubator/lattice/blob/master/terraform/google/README.md).
+
+Up-to-date installation instructions are on the [GitHub README](https://github.com/cloudfoundry-incubator/lattice/tree/<%= version %>).
+
+## How do I use Lattice?
+
+Start with the [getting-started tutorial](/docs/getting-started.html) for a brief introduction.
+
+Lattice provides an [HTTP API](/docs/lattice-api.html) for scheduling and monitoring work.  [`ltc` (the Lattice CLI)](/docs/ltc.html)  wraps this API and provides basic access to Lattice’s feature-set.
+
+## I'm having trouble launching my Docker image - help!
+
+Check out the [troubleshooting section](/docs/troubleshooting.html).
+
+## Is Lattice intended for multi-tenant deployments?
+
+No.  While built on top of a tech stack that supports secure multi-tenancy, Lattice is geared towards the developers or small teams with a high trust culture that need cluster computing solutions.  Lattice gives you "root access" to your cluster and minimizes as many barriers to entry as possible - including security barriers!
+
+## What software components make up Lattice?
+
+Lattice components are primarily written in Go.
+
+Lattice includes Cloud Foundry components [Diego](https://github.com/cloudfoundry-incubator/diego-design-notes), [Loggregator](https://github.com/cloudfoundry/loggregator) and [Router](https://github.com/cloudfoundry/gorouter).  Diego is responsible for scheduling and running containerized workloads.  Loggregator is responsible for streaming logs out of running containers.  The Router is responsible for load balancing HTTP traffic across running containers.
+
+## What is the relationship between Lattice and Diego?
+
+[Diego](https://github.com/cloudfoundry-incubator/diego-design-notes) is Cloud Foundry's next generation elastic runtime.  Lattice is a distribution of Diego that eschews most of Cloud Foundry's 'enterprise' features.  Lattice is built to let you easily deploy and interact with Diego.  New features that make their way into Diego will be available on Lattice almost immediately.
+
+To build a deep understanding of how Lattice works you'll need to learn about Diego.  The [design notes](https://github.com/cloudfoundry-incubator/diego-design-notes) are a good starting point for building a mental model of what is going on under the hood.
+
+## What is the relationship between Lattice and Docker?
+
+Lattice supports Docker images as a format for distributing container root filesystems.  Currently, Docker images must be publicly hosted on the [Docker Hub Registry](https://registry.hub.docker.com) or published to a signed private Docker registry without authentication.  Lattice uses Docker's libraries to fetch Docker image metadata and image layers, but it does *not* use the Docker daemon to run and manage containers.  Instead, Lattice uses [Garden](https://github.com/cloudfoundry-incubator/garden).  Garden provides a *platform-agnostic* API for launching and managing containers and is built to be consumed by a distributed container scheduler like Diego.  [Garden-Linux](https://github.com/cloudfoundry-incubator/garden-linux) is an implementation of the Garden API that provides containers on the Linux platform using kernel namespaces and cgroups - the same technologies used by Docker, LXC and Rocket.
+
+More details about how Lattice works with Docker images can be found [here](/docs/troubleshooting.html#how-does-lattice-work-with-docker-images).
+
+## What about Cloud Foundry Elastic Runtime, Kubernetes, Mesos and other clustered Docker projects?
+
+- **Cloud Foundry**: For small teams and some use cases, a complete Cloud Foundry deployment is overkill, can be difficult to get started and requires a footprint that does not fit on most developer laptops. We also wanted to make it possible to use Cloud Foundry components like the Router on their own and experiment more easily with new ideas before graduating them to full Cloud Foundry.  Lattice reuses Diego, Cloud Foundry’s next generation Elastic Runtime.
+
+- **Kubernetes**: Kubernetes, from Google, has a lot of great ideas and opinions that overlap with Lattice and some that don't. Kubernetes requires overlay networking and does not include features we believe are important like DNS load balancing and aggregated logging. At this time, Kubernetes only includes simple cluster scheduling in open source and does not use the cluster scheduler we imagine Google uses for production workloads. Kubernetes also requires awareness and implementations of concepts specific to Kubernetes like pods, replicaControllers and services that do not fit the simple user experience we envision.
+
+- **Mesos**: Apache Mesos is also a great project which provides distributed scheduling. Mesos is managing more of lower level primitives in the data center and requires applications be written for Mesos or the use of frameworks built on top of Mesos to target specific use cases. Some frameworks like Marathon provide higher level abstractions, but do not include features we wanted and do not fit the simpler developer and operator experience we are targeting.
+
+- **Other clustered container projects**: Most of the clustered Docker projects are very Docker-centric, missing features we wanted and do not have a pluggable container solution that would easily accommodate Windows or Rocket. There is obviously overlap and differences with many other projects. Lattice is an attempt to balance maximizing the utility of scalable clustering with a minimal feature set in line with our goals for easy deployment and a great user experience.
+
+## Is Lattice going to replace the existing Cloud Foundry Elastic Runtime?
+
+No. Lattice and Cloud Foundry Elastic Runtime serve different purposes with some of the same building blocks. Lattice provides a single user, single-tenant, cluster root, very-few-constraints developer experience without guard rails. Cloud Foundry Elastic Runtime serves full enterprise use cases including multi-user team development, multi-tenancy, auditing, services marketplace and quotas with enterprise guard rails. Lattice is intended to be a proving ground for developer and operator experience that influences features for Cloud Foundry Elastic Runtime.
+
+## What Cloud Foundry projects are not included with Lattice?
+
+- **UAA and Login Server**: Lattice is intended for single-tenancy. It is not intended to provide multi-tenancy for isolation as an API user effectively has cluster root permissions. Single user “basic auth” is currently the only authentication option.
+- **Cloud Controller**: Cloud Foundry’s API server has many enterprise features for multi-tenancy, a services marketplace and other enterprise abstractions that are not necessary for some basic container use cases.
+- **BOSH Mandated Packaging**: Any configuration management tool should work well with Lattice. We still recommend BOSH for production, but we recognize there are many choices for configuration and cluster lifecycle management.
+
+## How is Lattice governed?
+
+[Pivotal](http://www.pivotal.io) plans on submitting Lattice to the [Cloud Foundry Foundation incubation process](https://docs.google.com/a/pivotal.io/document/d/1_Jh-Dobalgie-w6Yp1-QSGKf0LEpBBit-mB3oYCBbtg/edit#heading=h.gjdgxs). Product direction is provided by a Product Manager, currently Onsi Fakhouri. Engineering governance is handled like other projects at Cloud Foundry Foundation which include Test Driven Development, Continuous Integration and other quality standards. [See CONTRIBUTING.md](https://github.com/cloudfoundry/cf-release/blob/master/CONTRIBUTING.md) for more detail.
+
+## How do I contribute or get involved with Lattice?
+
+- Review the public [Lattice](https://www.pivotaltracker.com/n/projects/1183596) and [Diego](https://www.pivotaltracker.com/n/projects/1003146) Pivotal Tracker projects
+- Get involved on the [Google Groups mailing list](https://groups.google.com/a/cloudfoundry.org/forum/#!forum/lattice)
+- Open issues on the GitHub repository for [Lattice](https://github.com/cloudfoundry-incubator/lattice)
+
+## What is the Lattice roadmap?
+
+See the public Pivotal Tracker project for [Lattice](https://www.pivotaltracker.com/n/projects/1183596) and [Diego](https://www.pivotaltracker.com/n/projects/1003146)
+
+## Is Lattice ready for production?
+
+Diego, the runtime component of Lattice is not in full production yet with Cloud Foundry, but is running a subset of [Pivotal Web Services](https://run.pivotal.io/) deployments. Diego is planned for full production use sometime early in Q2 of 2015.
+
+The Router and Loggregator components of Lattice have been in production with Cloud Foundry for over a year and we consider them production-ready.
+
+The deployment strategy employed by Lattice emphasizes convenience and simplicity.  When deployed with Terraform none of the Lattice VMs are monitored - should a VM fail it will not be recreated.  Moreover, Lattice minimizes overhead by running single instances of several components.  These constitute single-points of failure and should not be relied upon in a production setting.  If you need to set up a productionized deployment of Lattice you will need to be sure to make all the components redundant, plus provide monitoring and management on the hosts. As the project evolves and there is more experience in the community, we hope those solutions will emerge and be shared. Depending on the use case, we also recommend considering deploying Cloud Foundry with BOSH. Instructions for this are available on the [Diego-Release GitHub repository](https://github.com/cloudfoundry-incubator/diego-release).
+
+## How secure is Lattice?
+
+Security is not Lattice's primary concern.  Lattice is intended to provide a cluster root experience with minimal barriers to entry.  Multi-tenant workloads are not in scope.  Additionally, no effort is made to prevent containers from communicating with other components within a Lattice cluster.  Also, no effort is made to protect log streams behind an authentication layer - they are accessible to clients with network access to Lattice servers.
+
+As the project evolves and there is more experience in the community, we hope security solutions will emerge and be shared. Depending on the use case and security needs, we also recommend considering deploying Cloud Foundry with BOSH. Instructions for this are available on the [Diego-Release GitHub repository](https://github.com/cloudfoundry-incubator/diego-release).
+
+## What Operating Systems are supported?
+
+Lattice currently is developed and tested using Ubuntu Trusty 14.04 LTS.
+
+Lattice uses Cloud Foundry's [Garden-Linux](https://github.com/cloudfoundry-incubator/garden-linux) for Linux Containers, and the current Garden-Linux Backend does not yet support CentOS7. We would like to support CentOS7 and other Linux variants with a modern Linux 3.x kernel.  Get involved on the mailing list if you are interested in helping with this.
+
+## How much memory footprint does Lattice have?
+
+When running all of Lattice on a single VM, the process overhead in-use is about 250MB with no containers and no activity.
+
+When running Lattice in distributed mode with no containers and no activity, the Cell uses about 156MB of process overhead and the Brain uses about 141MB.

--- a/docs/lattice-api.md
+++ b/docs/lattice-api.md
@@ -1,0 +1,19 @@
+---
+title: Lattice API
+weight: 4
+doc_subnav: true
+---
+
+# The Lattice API
+
+`ltc` is simply a wrapper around a Lattice's powerful RESTful API.  Whereas `ltc` is geared towards launching Docker images on Lattice, you can use the underlying API to construct and request more elaborate container workloads.
+
+The Lattice API is provided by Diego's Receptor component.  You can learn about the API [here](https://github.com/cloudfoundry-incubator/receptor/blob/master/doc/README.md).  We recommend using the Golang client provided by the [Receptor](https://github.com/cloudfoundry-incubator/receptor).
+
+There are a handful of provisos to keep in mind when using the Diego Receptor API with Lattice:
+
+- Lattice does not ship with a default rootfs.  As such you must specify a Docker image for a rootfs.  One option is to use something lightweight like [busybox](https://registry.hub.docker.com/_/busybox/).  To use busybox set `rootfs: "docker:///library/busybox"` when constructing DesiredLRPs and Tasks.  
+ 
+  If you need a more complete Linux distribution you can use the rootfs that ships with Cloud Foundry ([lucid64](https://registry.hub.docker.com/u/cloudfoundry/lucid64/), [trust64](https://registry.hub.docker.com/u/cloudfoundry/trusty64/)).  Simply set `rootfs: "docker:///cloudfoundry/lucid64` or `rootfs: "docker:///cloudfoundry/trusty64`.  Be warned that these are quite large: the first container to launch on a given Cell will spend a while downloading the image.
+- Lattice does not apply any firewall rules to containers: any container talk to any other container (or any other endpoint within the VPC for that matter).  As such, there is no need to specify `egress_rules` for your Tasks and DesiredLRPs.
+- It is important to understand how [Lattice works with Docker images](/docs/troubleshooting.html#how-does-lattice-work-with-docker-images).  In short, as a consumer of the Lattice API it is your responsiblity to specify which command Lattice should run after mounting the Docker image file system.  `ltc` populates this information in the DesiredLRP by fetching the metadata associated with the Docker image from the Docker registry.

--- a/docs/ltc.md
+++ b/docs/ltc.md
@@ -1,0 +1,153 @@
+---
+title: ltc - The Lattice CLI
+weight: 3
+doc_subnav: true
+---
+
+# `ltc` - The Lattice CLI
+
+`ltc` wraps the [Lattice API](/docs/lattice-api.html) and provides a simple interface for launching and managing applications based on Docker images.  This document is a reference detailing all of `ltc`'s subcommands and options.  You may find it helpful to also build a deeper understanding of how Lattice [manages applications](/docs/troubleshooting.html#how-does-lattice-manage-applications) and [Docker images](/docs/troubleshooting.html#how-does-lattice-work-with-docker-images).
+
+You can download the CLI from the [GitHub Releases](https://github.com/cloudfoundry-incubator/lattice/releases) page.
+
+## Targetting Lattice
+
+### `ltc target`
+
+You use `ltc target` to point `ltc` at a deployed Lattice installation. For a Vagrant deployed local Lattice the default should be: `ltc target 192.168.11.11.xip.io`
+
+If the Lattice API is password protected, `ltc` will prompt you for a username and password.
+
+Run `ltc target` with no arguments to get the current target.
+
+## Launching and Managing Applications
+
+### `ltc create`
+
+`ltc create APP_NAME DOCKER_IMAGE` launches Docker image based applications in a Lattice cluster.
+
+- `APP_NAME` is required and must be unique across the Lattice cluster.  `APP_NAME` is used to refer to the application and to route to the application.  For example, an application named `lattice-app` will be accessible at `lattice-app.192.168.11.11.xip.io`
+- `DOCKER_IMAGE` is required and must match the standard Docker image format (e.g. `cloudfoundry/lattice-app`)
+
+When launching a Docker image, `ltc` first queries the Docker registry for metadata associated with the image.  It uses this information to:
+
+- construct the start command based on the `ENTRYPOINT` and `CMD` associated with the Docker image
+- identify the working directory based on the `WORKDIR` associated with the Docker image
+- open up ports based on any `EXPOSE` directives associated with the Docker image
+
+With this metadata in hand, `ltc` submits a request to launch the application to Lattice.  This request includes information on how to monitor the health of the application and how to route traffic to the application.
+
+The default behavior of `ltc create`, outlined above, can be modified via a series of additional command line flags:
+
+- **`--working-dir=/path/to/working-dir`** sets the working directory, overriding the default associated with the Docker image.
+- **`--run-as-root`** launches the command in the process as the root user.  By default, Lattice uses a non-root user created at container-creation time.  Lattice does not yet honor the Docker USER directive.  There are plans to address this soon.  For most containers `--run-as-root` is a sufficient workaround.
+- **`--env NAME[=VALUE]`** specifies environment variables. You can have multiple `--env` flags.  These are merged *on top of* the Environment variables extracted from the Docker image metadata.  Passing an --env flag without explicitly setting the VALUE uses the current execution context to set the value.
+- **`--memory-mb=128`** specifies the memory limit to apply to the container.  To allow unlimited memory usage, set this to 0.
+- **`--disk-mb=1024`** specifies the disk limit to apply to the container.  This governs any writes *on top of* the root filesystem mounted into the container.  To allow unlimited disk usage, set this to 0.
+- **`--cpu-weight=100`** specifies the relative CPU weight to apply to the container (scale 1-100).
+- **`--instances=1`** specifies the number of instances of the application to launch.  This can also be modified after the application is started.
+- **`--no-monitor`** disables health monitoring.  Lattice will consider the application crashed only if it exits.
+- **`--timeout=2m`** sets the maximum polling duration for starting the app.
+
+Finally, one can override the default start command by specifiying a start command after a `--` separator.  This can be followed by any arguments one wishes to pass to the app.  For example:
+
+    ltc create lattice-app cloudfoundry/lattice-app -- /lattice-app -quiet=true
+
+#### Managing Mulitple Ports
+
+By default, `ltc` requests that Lattice open up all ports specified by the `EXPOSE` directive associated with the Docker image.  It then sets up a route to send HTTP traffic to each exposed port.  For example, an application named `my-app` that exposes ports `8080` and `9000` will get the following set of default routes:
+
+- `my-app.192.168.11.11.xip.io` will map to port `8080` (the bare `my-app` route always routes to the *lowest* exposed port)
+- `my-app-8080.192.168.11.11.xip.io` will map to port `8080`
+- `my-app-9000.192.168.11.11.xip.io` will map to port `9000`
+
+In addition to setting up these routes, `ltc` will set up a health check that verifies the application is listening on port `8080` (the healthcheck is always bound to the *lowest* port).
+
+You can modify all of this behavior from the command line:
+
+- **`--port=8080,9000`** allows you to specify the set of ports to open on the container.  This overrides any `EXPOSE` directives associated with the Docker image.  When specifying multiple ports via `--port` you must also specify a `--monitored-port` to perform the health-check on (or, alternatively, turn off the health-check via `--no-monitor`).
+- **`--monitored-port=8080`** allows you to modify the port that `ltc` chooses to perform the health-check on.
+- **`--routes=8080:my-app,9000:my-app-admin`** allows you to specify the routes to map to the requested ports.  In this example, `my-app.192.168.11.11.xip.io` will map to port `8080` and `my-app-admin.192.168.11.11.xip.io` will map to port `9000`.
+
+  You can repeat the port entry to attach multiple routes to the same port (e.g. `--routes=8080:my-app,8080:my-app-alias`).
+
+> For instances with *multiple* `EXPOSE` directives, `ltc` selects the *lowest* port for the purposes of routing traffic and performing the health check.
+
+### `ltc remove`
+
+`ltc remove APP_NAME` removes an application entirely from a Lattice deployment.  To stop an application without removing it, try `ltc scale APP_NAME 0`.
+
+`ltc remove` accepts the following additional command line flag(s):
+
+- **`--timeout=2m`** sets the maximum polling duration for removing the app.
+
+### `ltc scale` 
+
+`ltc scale APP_NAME NUM_INSTANCES` modifies the number of running instances of an application.
+
+`ltc scale` accepts the following additional command line flag(s):
+
+- **`--timeout=2m`** sets the maximum polling duration for scaling the app.
+
+### `ltc update-routes`
+
+`ltc update-routes APP_NAME PORT:ROUTE,PORT:ROUTE,...` allows you to update the routes associated with an application *after* it has been deployed.  The format is identical to the `--routes` option on `ltc create`.
+
+The set of routes passed into `ltc update-routes` will *override* the existing set of routes - these modification will start working shortly after the call to `update-routes`.
+
+### `ltc create-lrp`
+
+`ltc create-lrp /path/to/json` creates an application with the configuration specified in the JSON.  The syntax of the JSON can be found at the [Receptor API docs](https://github.com/cloudfoundry-incubator/receptor/blob/master/doc/lrps.md#describing-desiredlrps)
+
+## Streaming Logs
+
+### `ltc logs`
+
+`ltc logs APP_NAME` attaches to a log stream for a running application.  The logstream aggregates logs from *all* instances associated with an application.
+
+## What's Running on Lattice?
+
+### `ltc list`
+
+`ltc list` displays all applications currently running on the targetted Lattice deployment.  This includes information on the number of requested and running instances for each application, and routing information for accessing the application.
+
+### `ltc status`
+
+`ltc status APPLICATION_NAME` provides detailed information about an application running on the Lattice deployment.
+
+The first section in the status report includes information about the *desired* state of the application: how many instances should be running, what route to associate with the application, etc..
+
+The subsequent sections include information about individual instances of the application.  Here's some example output:
+
+    ================================================================================
+          Instance 0  [RUNNING]
+    --------------------------------------------------------------------------------
+    InstanceGuid    b75f58d2-4fc6-4c38-7097-42caf32ffc07
+    Cell ID         lattice-cell-01
+    Ip              192.168.11.11
+    Ports           61001:7777;61002:9999
+    Since           2015-02-06 16:52:40 (PST)
+    --------------------------------------------------------------------------------
+
+This indicates that instance 0 of the application has been `RUNNING` on `lattice-cell-01` since `2015-02-06 16:52:40 (PST)`.  The application can be reached at the indicated ip address (`192.168.11.11`).  This particular application included two EXPOSE directives, one for port  `7777` the other for port `9999`.  The `Ports` section of the report indicates the host-side ports that can be used to connect to the application at the requested container-side ports.  For example, to connect to `7777` one goes to `192.168.11.11:61001`.  To connect to `9999` one goes to `192.168.11.11:61002`.
+
+### `ltc visualize`
+
+`ltc visualize` displays the *distribution* of application instances across the targetted Lattice deployment.  Each running application is rendered as a green dot.  Starting applications are rendered as yellow dots.
+
+- **`--rate=1s`** refreshes the output at the specified time interval
+
+## Is Lattice Working?
+
+### `ltc test`
+
+`ltc test` runs a minimal integration suite to ensure that a Lattice deploy is functioning correctly.
+
+- **`-v`** verbose mode.  shows application output during test suite.
+- **`--timeout=30s`** sets the wait time for Lattice to respond.
+
+### `ltc debug-logs`
+
+`ltc debug-logs` streams back logs from some of Lattice's key components.  This is useful for debugging situations where containers fail to get created/torn down.
+
+

--- a/docs/private-docker-registry.md
+++ b/docs/private-docker-registry.md
@@ -1,0 +1,59 @@
+---
+title: Private Docker Registry
+weight: 7
+doc_subnav: true
+---
+
+# Private Docker Registries
+
+Lattice does not currently ship with a private Docker registry.  We plan on remedying this soon to improve our developer experience.  Until then, follow these instructions to spin up a Docker registry on boot2docker, configure the Docker daemon on boot2docker, configure Lattice to allow communication with the private registry, and then import a Docker image to the private registry and launch it via Lattice.
+
+## Launch a Private Docker Registry and configure the Docker daemon via boot2docker
+
+The following assumes:
+
+* Using the latest [http://boot2docker.io/](http://boot2docker.io/)
+* Using IP 192.168.59.103 for boot2docker. Find the ip on your boot2docker vm with `boot2docker ip`
+
+**1. Allow the Docker daemon to communicate with the private registry**
+
+Use `boot2docker ssh` to update/create the file `/var/lib/boot2docker/profile` and restart docker:
+
+    sudo su
+    echo 'EXTRA_ARGS="--insecure-registry 192.168.59.103:5000"' >> /var/lib/boot2docker/profile
+    /etc/init.d/docker restart
+
+**2. Launch the private registry on boot2docker**
+
+From your host machine:
+
+    docker run -p 5000:5000 registry
+
+## Lattice VM configuration
+
+The following assumes you are using the local Vagrant VM.
+
+**Allow Garden-Linux to communicate with the private registry**
+
+SSH to the Lattice VM with `vagrant ssh` from the directory with the Lattice Vagrantfile then modify the Garden-Linux config file (`/etc/init/garden-linux.conf`) and restart Garden-Linux:
+
+    sudo sed -i '15i-insecureDockerRegistryList="192.168.59.103:5000" \\' /etc/init/garden-linux.conf
+    sudo initctl stop garden-linux
+    sudo initctl start garden-linux
+
+## Push an example docker image to the private registry
+
+Pull the lattice-app image from DockerHub and push it to the local private registry:
+
+    docker pull cloudfoundry/lattice-app
+    IMAGE_ID=`docker images | grep lattice-app | awk '{ print $3 }'`
+    docker tag $IMAGE_ID 192.168.59.103:5000/lattice-app
+    docker push 192.168.59.103:5000/lattice-app
+
+## Launch the docker image hosted on the private registry on Lattice
+
+    ltc create private-lattice-app 192.168.59.103:5000/lattice-app
+
+If there is a problem, run `ltc debug-logs` in a shell while you `ltc remove private-lattice-app` and retry the `ltc create`.
+
+> Note: you will need `ltc` version 0.2.3 or greater.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,86 @@
+---
+title: Troubleshooting
+weight: 5
+doc_subnav: true
+---
+
+# Troubleshooting
+
+## How does Lattice manage applications?
+
+A helpful step when debugging is to have an accurate mental model of the system in question.
+
+Lattice is founded upon the notions of eventual consistency.  In particular, Lattice is constantly working to reconcile *desired* state with *actual* state.
+
+When you issue commands via the `ltc` CLI (or the Lattice API) you are modifying Lattice's *desired* state.  Typically, you are informing Lattice about a desire to run some number of instances of an application.  Lattice updates this desired state **synchronously**.
+
+The *actual* state (i.e. the set of running instances), however, is updated **asynchronously** as the Lattice cluster works to reconcile the current *actual* state with the *desired* state.
+
+Typically, when the user updates *desired* state Lattice immediately takes actions to perform this reconciliation.  Should an action fail (perhaps a network partition occurs) or a running instance be lost (perhaps a Cell explodes) Lattice will eventually attempt to reconcile actual and desired state again (this happens every 30 seconds - though Lattice can detect a missing Cell within ~5 seconds).
+
+## How does Lattice work with Docker images?
+
+A Docker image consists of two things: a collection of layers to download and mount (the raw bits that form the file system) and metadata that describes what command should be launched (the `ENTRYPOINT` and `CMD` directives, among others, specified in the Dockerfile).
+
+Lattice uses [Garden-Linux](https://github.com/cloudfoundry-incubator/garden-Linux) to construct Linux containers.  These containers are built on the same Linux kernel technologies that power all Linux containers: namespaces and cgroups.  When a container is created a file system must be mounted as the root file system of the container.  Garden-Linux supports mounting Docker images as root file systems for the containers it constructs.  Garden-Linux takes care of fetching and caching the individual layers associated with the Docker image and combining and mounting them as the root file system - it does this using the same libraries that power Docker.
+
+This yields a container with contents that exactly match the contents of the associated Docker image.
+
+Once a container is created Lattice is responsible for running and monitoring processes in the container.  The Lattice API allows the user to define exactly which commands to run within the container; in particular, it is possible to run, monitor, and route to *multiple* processes within a single container.
+
+When launching a Docker image, `ltc` directs Lattice to create a container backed by the Docker image's root fs, and to run the command encoded in the Docker image's metadata.  It does this by fetching the metadata associated with the Docker image (using the same libraries that power Docker) and making the appropriate Lattice API calls.  `ltc` allows users to easily override the values it pulls out of the Docker image metadata.  This is outlined in detail in the [`ltc` documentation](/docs/ltc.html#ltc-start).
+
+There are two remaining areas of Docker compatbility that we are working on:
+
+- Removing assumptions about container contents.  Currently, Garden-Linux makes some assumptions about what is available inside the container.  Some Docker images do not satisfy these assumptions though most do (the liteweight busybox base image, for example).
+- Supporting arbitrary UIDs and GIDs.  Currently Garden-Linux runs applications as the `vcap` user (a historical holdover).  One can side-step this with `--run-as-root` (see below) though this is suboptimal.  We intend to fully support the USER directive and (moreover) to improve our API around specifying which user should run the command.
+
+## I can't run my Docker image.  Help!
+
+Here are a few pointers to help you debug and fix some common issues:
+
+### Increase `ltc`'s Timeout
+
+`ltc create` will wait up to one minute for your application to start.  If this fails it may be that your Docker container is large and has not downloaded yet.  You can set the `LATTICE_CLI_TIMEOUT` environment variable (in seconds) to instruct `ltc` to wait longer.  Note that `ltc` does not remove your application when this timeout occurs, so your application may eventually start in the background.
+
+### Increase Memory and Disk Limits
+
+By default, `ltc` applies a memory limit of 128MB and a disk limit of 1024MB to the container.  If your process is exiting prematurely it may be attempting to consume more than 128MB of memory.  You can increase the limit using the `--memory-mb` flag.  To turn off memory and disk limits set `--memory-mb` and `--disk-mb` to `0`.
+
+### Check the Application Logs
+
+`ltc logs APP_NAME` will aggregate and stream application logs.  These may point you in the right direction.  In particular, if you see issues related to file permissions or a health check failing, read on...
+
+### Run as Root
+
+Lattice runs the process in your Docker image as an unprivileged user.  Sometimes this user does not have privileges to execute the requested process - you can try using the `--run-as-root` flag to get around this limitation.
+
+> We have plans to build more robust support for specifying the user/uid/group/gid to run the container as.
+
+### Disable Health Monitoring
+
+By default, `ltc` requests that Lattice perform a periodic health check agains the running application.  This health check verifies that the application is listening on a port.  For applications that do not listen on ports (e.g. a worker that does not expose an endpoint) you can disable the health check via the `--no-monitor` flag.
+
+### Watch Lattice Component Logs
+
+If you're still stuck you can try streaming the Lattice debug-logs with `ltc debug-logs` while launching your application. [The veritas cli](https://github.com/pivotal-cf-experimental/veritas) is helpful for pretty printing the json log format from `ltc debug-logs` into something more human readable with a command like `ltc debug-logs | veritas chug`.
+
+### How do I get a shell inside a lattice container.
+
+See this detailed step-by-step set of instructions for how to [get shell access to a container running on lattice](https://docs.google.com/a/pivotal.io/document/d/1WWoQ_d5nR4-P6VfLbAAbzOZIvRj-Xdff2hsjM_ZWRUQ/edit#heading=h.hwnzq0ni9hoj).
+
+## How do I communicate with my containers over TCP?
+
+The Lattice router only supports HTTP communication at this time.  If you would like to use TCP instead you will need to communicate with the container by IP and port, which you can get via `ltc status`.  For a local vagrant deployed Lattice, the containers can be reached at `192.168.11.11`.  On AWS, you will need to configure your ELB to route traffic to the Cells in your VPC.
+
+## How do I communicate between containers?
+
+Lattice does not apply any firewall rules between containers.  Any container can freely communicate with any other container.  All you need is to identfiy the IP and Port - information available via `ltc status` or the [Receptor API](https://github.com/cloudfoundry-incubator/receptor/blob/master/doc/README.md).
+
+## How do I do service discovery?
+
+Outside of the HTTP router, Lattice does not ship with a service discovery solution.  It is relatively straightforward, however, to build a solution on top of the Receptor API.  We have plans to explore this space soon after release.
+
+## How do I upgrade Lattice?
+
+Lattice [does not support rolling upgrades](/docs/#is-lattice-ready-for-production).


### PR DESCRIPTION
This PR open-sources the documentation that previously was available only through [lattice.cf](http://lattice.cf/).

Also adds Middleman frontmatter, which looks fine when viewed on the Github site, and allows the docs to be auto-rendered for [lattice.cf](http://lattice.cf/).
