### PR TITLE
have cells join a default zone of z1 to match metron and others

### DIFF
--- a/cluster/cell/upstart/rep.conf
+++ b/cluster/cell/upstart/rep.conf
@@ -15,7 +15,8 @@ script
         -consulCluster="http://127.0.0.1:8500" \
         -executorURL=http://127.0.0.1:1700 \
         -cellID=$LATTICE_CELL_ID \
-        -rootFSProvider=docker \
+        -zone=z1 \
+	-rootFSProvider=docker \
         >> /var/lattice/log/rep-service.log 2>&1
 
 end script

--- a/terraform/aws/example/lattice.aws.tf
+++ b/terraform/aws/example/lattice.aws.tf
@@ -16,6 +16,9 @@ module "lattice-aws" {
     # The number of Lattice Cells to launch
     num_cells = "3"
 
+    # The default is your elastic IP.xip.io
+    aws_system_domain = "${aws_eip.ip.public_ip}.xip.io"
+
     #################################
     ###  Optional Settings Below  ###
     #################################

--- a/terraform/aws/resources.tf
+++ b/terraform/aws/resources.tf
@@ -63,10 +63,10 @@ resource "aws_eip" "ip" {
         key_file = "${var.aws_ssh_private_key_file}"
     }
     provisioner "remote-exec" {
-        inline = [       
-          "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.ip.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
+        inline = [
+          "sudo sh -c 'echo \"SYSTEM_DOMAIN=${var.aws_system_domain}\" >> /var/lattice/setup/lattice-environment'",
           "sudo shutdown -r now"
-        ]   
+        ]
 }
 
 
@@ -172,7 +172,7 @@ resource "aws_instance" "cell" {
         inline = [
             "sudo mkdir -p /var/lattice/setup",
             "sudo sh -c 'echo \"CONSUL_SERVER_IP=${aws_instance.lattice-brain.private_ip}\" >> /var/lattice/setup/lattice-environment'",
-            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${aws_eip.ip.public_ip}.xip.io\" >> /var/lattice/setup/lattice-environment'",
+            "sudo sh -c 'echo \"SYSTEM_DOMAIN=${var.aws_system_domain}\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"LATTICE_CELL_ID=cell-${count.index}\" >> /var/lattice/setup/lattice-environment'",
             "sudo sh -c 'echo \"GARDEN_EXTERNAL_IP=$(hostname -I | awk '\"'\"'{ print $1 }'\"'\"')\" >> /var/lattice/setup/lattice-environment'",
         ]
@@ -183,5 +183,3 @@ resource "aws_instance" "cell" {
     }
 
 }
-
-


### PR DESCRIPTION
Not sure if there is a lattice use case to bubble this up into lattice-environment since you can't deploy more than one. It would be nice to have this match the rest of the components on a cell like metron.
