### PR TITLE
Implemented Themed help text Part2

### DIFF
--- a/ltc/cli_app_factory/app_help.go
+++ b/ltc/cli_app_factory/app_help.go
@@ -1,0 +1,158 @@
+package cli_app_factory
+
+import (
+	"fmt"
+	"os"
+	"reflect"
+	"strings"
+	"text/tabwriter"
+	"text/template"
+	"unicode/utf8"
+
+	"github.com/codegangsta/cli"
+)
+
+type groupedCommands struct {
+	Name             string
+	CommandSubGroups [][]cmdPresenter
+}
+
+func (c groupedCommands) SubTitle(name string) string {
+	return (name + ":")
+}
+
+type cmdPresenter struct {
+	Name        string
+	Description string
+}
+
+func presentCmdName(cmd cli.Command) (name string) {
+	name = strings.Join(cmd.Names(), ", ")
+	return
+}
+
+type appPresenter struct {
+	cli.App
+	Commands []groupedCommands
+}
+
+func newAppPresenter(app *cli.App) (presenter appPresenter) {
+	maxNameLen := 0
+	for _, cmd := range app.Commands {
+		name := presentCmdName(cmd)
+		if utf8.RuneCountInString(name) > maxNameLen {
+			maxNameLen = len(name)
+		}
+	}
+
+	presentCommand := func(commandName string) (presenter cmdPresenter) {
+		cmd := app.Command(commandName)
+		presenter.Name = presentCmdName(*cmd)
+
+		padding := strings.Repeat(" ", maxNameLen-utf8.RuneCountInString(presenter.Name))
+		presenter.Name = presenter.Name + padding
+		presenter.Description = cmd.Usage
+
+		return
+	}
+
+	presenter.Name = app.Name
+	presenter.Flags = app.Flags
+	presenter.Usage = app.Usage
+	presenter.Version = app.Version
+	presenter.Authors = app.Authors
+	presenter.Commands = []groupedCommands{
+		{
+			Name: "TARGET LATTICE",
+			CommandSubGroups: [][]cmdPresenter{
+				{
+					presentCommand("target"),
+				},
+			},
+		}, {
+			Name: "CREATE AND MODIFY APPS",
+			CommandSubGroups: [][]cmdPresenter{
+				{
+					presentCommand("create"),
+					presentCommand("remove"),
+					presentCommand("scale"),
+					presentCommand("update-routes"),
+				},
+			},
+		}, {
+			Name: "STREAM LOGS",
+			CommandSubGroups: [][]cmdPresenter{
+				{
+					presentCommand("logs"),
+				},
+			},
+		}, {
+			Name: "SEE WHATS RUNNING",
+			CommandSubGroups: [][]cmdPresenter{
+				{
+					presentCommand("cells"),
+					presentCommand("list"),
+					presentCommand("status"),
+					presentCommand("visualize"),
+				},
+			},
+		}, {
+			Name: "ADVANCED",
+			CommandSubGroups: [][]cmdPresenter{
+				{
+					presentCommand("create-lrp"),
+				},
+			},
+		}, {
+			Name: "HELP AND DEBUG",
+			CommandSubGroups: [][]cmdPresenter{
+				{
+					presentCommand("debug-logs"),
+					presentCommand("test"),
+					presentCommand("help"),
+				},
+			},
+		},
+	}
+
+	return
+}
+
+func ShowHelp(helpTemplate string, thingToPrint interface{}) {
+	translatedTemplatedHelp := strings.Replace(helpTemplate, "{{", "[[", -1)
+	translatedTemplatedHelp = strings.Replace(translatedTemplatedHelp, "[[", "{{", -1)
+
+	switch thing := thingToPrint.(type) {
+	case *cli.App:
+		showAppHelp(translatedTemplatedHelp, thing)
+	case cli.Command:
+		commandPrintHelp(translatedTemplatedHelp, thing)
+	default:
+		panic(fmt.Sprintf("Help printer has received something that is neither app nor command! The beast (%s) looks like this: %s", reflect.TypeOf(thing), thing))
+	}
+}
+
+func showAppHelp(helpTemplate string, appToPrint *cli.App) {
+	presenter := newAppPresenter(appToPrint)
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	t := template.Must(template.New("help").Parse(helpTemplate))
+	err := t.Execute(w, presenter)
+	if err != nil {
+		panic(err)
+	}
+	w.Flush()
+}
+
+func commandPrintHelp(templ string, data cli.Command) {
+	funcMap := template.FuncMap{
+		"join": strings.Join,
+	}
+
+	w := tabwriter.NewWriter(os.Stdout, 0, 8, 1, '\t', 0)
+	t := template.Must(template.New("help").Funcs(funcMap).Parse(templ))
+	err := t.Execute(w, data)
+	if err != nil {
+		panic(err)
+	}
+	w.Flush()
+}

--- a/ltc/cli_app_factory/app_help_test.go
+++ b/ltc/cli_app_factory/app_help_test.go
@@ -1,0 +1,83 @@
+package cli_app_factory_test
+
+import (
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/cloudfoundry-incubator/lattice/ltc/cli_app_factory"
+	"github.com/cloudfoundry-incubator/lattice/ltc/config"
+	"github.com/cloudfoundry-incubator/lattice/ltc/config/persister"
+	"github.com/cloudfoundry-incubator/lattice/ltc/config/target_verifier/fake_target_verifier"
+	"github.com/cloudfoundry-incubator/lattice/ltc/exit_handler/fake_exit_handler"
+	"github.com/cloudfoundry-incubator/lattice/ltc/terminal"
+	"github.com/cloudfoundry-incubator/lattice/ltc/test_helpers/io"
+	"github.com/codegangsta/cli"
+	"github.com/onsi/gomega/gbytes"
+	"github.com/pivotal-golang/lager"
+)
+
+var _ = Describe("AppHelp", func() {
+	var (
+		fakeTargetVerifier *fake_target_verifier.FakeTargetVerifier
+		memPersister       persister.Persister
+		outputBuffer       *gbytes.Buffer
+		terminalUI         terminal.UI
+		cliApp             *cli.App
+		cliConfig          *config.Config
+		latticeVersion     string
+	)
+
+	BeforeEach(func() {
+		fakeTargetVerifier = &fake_target_verifier.FakeTargetVerifier{}
+		memPersister = persister.NewMemPersister()
+		outputBuffer = gbytes.NewBuffer()
+		terminalUI = terminal.NewUI(nil, outputBuffer, nil)
+		cliConfig = config.New(memPersister)
+		latticeVersion = "v0.2.Test"
+	})
+
+	JustBeforeEach(func() {
+		cliApp = cli_app_factory.MakeCliApp(
+			latticeVersion,
+			"~/",
+			&fake_exit_handler.FakeExitHandler{},
+			cliConfig,
+			lager.NewLogger("test"),
+			fakeTargetVerifier,
+			terminalUI,
+		)
+	})
+
+	It("shows help for all commands", func() {
+
+		dummyTemplate := `
+{{range .Commands}}{{range .CommandSubGroups}}{{range .}}
+{{.Name}}
+{{end}}{{end}}{{end}}
+`
+
+		cliCommands := cliApp.Commands
+		Expect(cliCommands).NotTo(BeEmpty())
+
+		output := io.CaptureOutput(func() {
+			cli_app_factory.ShowHelp(dummyTemplate, cliApp)
+		})
+
+		for _, command := range cliCommands {
+			Expect(commandInOutput(command.Names(), output)).To(BeTrue(), command.Name+" not in help")
+		}
+	})
+
+})
+
+func commandInOutput(cmdName []string, output []string) bool {
+	commandName := strings.Join(cmdName, ", ")
+	for _, line := range output {
+		if strings.TrimSpace(line) == strings.TrimSpace(commandName) {
+			return true
+		}
+	}
+	return false
+}

--- a/ltc/cli_app_factory/cli_app_factory_test.go
+++ b/ltc/cli_app_factory/cli_app_factory_test.go
@@ -2,7 +2,6 @@ package cli_app_factory_test
 
 import (
 	"errors"
-	"sort"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -63,17 +62,7 @@ var _ = Describe("CliAppFactory", func() {
 			Expect(cliApp.Email).To(Equal("cf-lattice@lists.cloudfoundry.org"))
 			Expect(cliApp.Usage).To(Equal(cli_app_factory.LtcUsage))
 			Expect(cliApp.Commands).NotTo(BeEmpty())
-		})
 
-		It("lists the subcommands in alphabetical order", func() {
-			cliCommands := cliApp.Commands
-			Expect(cliCommands).NotTo(BeEmpty())
-
-			var commandNames []string
-			for _, cmd := range cliCommands {
-				commandNames = append(commandNames, cmd.Name)
-			}
-			Expect(sort.StringsAreSorted(commandNames)).To(BeTrue())
 		})
 
 		Context("when invoked without latticeVersion set", func() {

--- a/ltc/main.go
+++ b/ltc/main.go
@@ -1,13 +1,150 @@
 package main
 
 import (
+	"errors"
+	"fmt"
 	"os"
+	"strconv"
+	"strings"
 
 	"github.com/cloudfoundry-incubator/lattice/ltc/setup_cli"
+	"github.com/codegangsta/cli"
 )
 
 func main() {
 	defer os.Stdout.Write([]byte("\n"))
+	var badFlags string
 	cliApp := setup_cli.NewCliApp()
-	cliApp.Run(os.Args)
+	if len(os.Args) > 1 {
+		flags := GetCommandFlags(cliApp, os.Args[1])
+		badFlags = matchArgAndFlags(flags, os.Args[2:])
+		if badFlags != "" {
+			badFlags = badFlags + "\n\n"
+		}
+	}
+	injectHelpTemplate(badFlags)
+	if len(os.Args) == 1 || os.Args[1] == "help" || os.Args[1] == "h" || requestHelp(os.Args[1:]) {
+		cliApp.Run(os.Args)
+	} else {
+		callCoreCommand(os.Args[0:], cliApp)
+	}
+}
+
+func injectHelpTemplate(badFlags string) {
+	cli.CommandHelpTemplate = fmt.Sprintf(`%sNAME:
+   {{join .Names ", "}} - {{.Usage}}
+{{with .ShortName}}
+ALIAS:
+   {{.Aliases}}
+{{end}}
+USAGE:
+   {{.Description}}{{with .Flags}}
+OPTIONS:
+{{range .}}   {{.}}
+{{end}}{{else}}
+{{end}}`, badFlags)
+}
+
+func matchArgAndFlags(flags []string, args []string) string {
+	var badFlag string
+	var lastPassed bool
+	multipleFlagErr := false
+Loop:
+	for _, arg := range args {
+		prefix := ""
+		//only take flag name, ignore value after '='
+		arg = strings.Split(arg, "=")[0]
+		if arg == "--h" || arg == "-h" || arg == "--help" || arg == "-help" {
+			continue Loop
+		}
+		if strings.HasPrefix(arg, "--") {
+			prefix = "--"
+		} else if strings.HasPrefix(arg, "-") {
+			prefix = "-"
+		}
+		arg = strings.TrimLeft(arg, prefix)
+		//skip verification for negative integers, e.g. -i -10
+		if lastPassed {
+			lastPassed = false
+			if _, err := strconv.ParseInt(arg, 10, 32); err == nil {
+				continue Loop
+			}
+		}
+		if prefix != "" {
+			for _, flag := range flags {
+				for _, f := range strings.Split(flag, ", ") {
+					flag = strings.TrimSpace(f)
+					if flag == arg {
+						lastPassed = true
+						continue Loop
+					}
+				}
+			}
+			if badFlag == "" {
+				badFlag = fmt.Sprintf("\"%s%s\"", prefix, arg)
+			} else {
+				multipleFlagErr = true
+				badFlag = badFlag + fmt.Sprintf(", \"%s%s\"", prefix, arg)
+			}
+		}
+	}
+	if multipleFlagErr && badFlag != "" {
+		badFlag = fmt.Sprintf("%s %s", "Unknown flags:", badFlag)
+	} else if badFlag != "" {
+		badFlag = fmt.Sprintf("%s %s", "Unknown flag", badFlag)
+	}
+	return badFlag
+}
+
+func requestHelp(args []string) bool {
+	for _, v := range args {
+		if v == "-h" || v == "--help" {
+			return true
+		}
+	}
+	return false
+}
+
+func callCoreCommand(args []string, cliApp *cli.App) {
+	err := cliApp.Run(args)
+	if err != nil {
+		os.Exit(1)
+	}
+}
+
+func GetCommandFlags(app *cli.App, command string) []string {
+	cmd, err := GetByCmdName(app, command)
+	if err != nil {
+		return []string{}
+	}
+	var flags []string
+	for _, flag := range cmd.Flags {
+		switch t := flag.(type) {
+		default:
+		case cli.StringSliceFlag:
+			flags = append(flags, t.Name)
+		case cli.IntFlag:
+			flags = append(flags, t.Name)
+		case cli.StringFlag:
+			flags = append(flags, t.Name)
+		case cli.BoolFlag:
+			flags = append(flags, t.Name)
+		case cli.DurationFlag:
+			flags = append(flags, t.Name)
+		}
+	}
+	return flags
+}
+
+func GetByCmdName(app *cli.App, cmdName string) (cmd *cli.Command, err error) {
+	cmd = app.Command(cmdName)
+	if cmd == nil {
+		for _, c := range app.Commands {
+			if c.ShortName == cmdName {
+				return &c, nil
+			}
+		}
+		err = errors.New("Command not found")
+	}
+	return
 }

--- a/ltc/test_helpers/io/io.go
+++ b/ltc/test_helpers/io/io.go
@@ -1,0 +1,57 @@
+package io
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+)
+
+func CaptureOutput(block func()) []string {
+	oldSTDOUT := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		panic(err)
+	}
+
+	os.Stdout = w
+	defer func() {
+		os.Stdout = oldSTDOUT
+	}()
+
+	doneWriting := make(chan bool)
+	result := make(chan []string)
+
+	go captureOutputAsyncronously(doneWriting, result, r)
+
+	block()
+	w.Close()
+	doneWriting <- true
+	return <-result
+}
+
+/*
+ The reason we're doing is that you can't write an infinite amount of bytes into a pipe.
+ On some platforms, the limit is fairly high; on other platforms, the limit is infuriatingly small
+ (looking at you, Windows). To counteract this, we need to read in a goroutine from one end of
+ the pipe and return the result across a channel.
+*/
+func captureOutputAsyncronously(doneWriting <-chan bool, result chan<- []string, reader io.Reader) {
+	var readingString string
+	for {
+		var buf bytes.Buffer
+		io.Copy(&buf, reader)
+		readingString += buf.String()
+		_, ok := <-doneWriting
+		if ok {
+			// there is no guarantee that the writer did not
+			// write more in between the read above and reading from this channel
+			// so we absolute must read once more if we want all the bytes
+			var buf bytes.Buffer
+			io.Copy(&buf, reader)
+			readingString += buf.String()
+			break
+		}
+	}
+	result <- strings.Split(readingString, "\n")
+}

--- a/ltc/test_helpers/io/io_suite_test.go
+++ b/ltc/test_helpers/io/io_suite_test.go
@@ -1,0 +1,13 @@
+package io_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestIo(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Io Suite")
+}

--- a/ltc/test_helpers/io/io_test.go
+++ b/ltc/test_helpers/io/io_test.go
@@ -1,0 +1,21 @@
+package io_test
+
+import (
+	. "github.com/cloudfoundry-incubator/lattice/ltc/test_helpers/io"
+	"os"
+	"strings"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("io helpers", func() {
+	It("will never overflow the pipe", func() {
+		str := strings.Repeat("z", 75000)
+		output := CaptureOutput(func() {
+			os.Stdout.Write([]byte(str))
+		})
+
+		Expect(output).To(Equal([]string{str}))
+	})
+})


### PR DESCRIPTION
[#91286798]

Hello! Team,

Apologies for the delay.  We have tried our best to implement the themed help text in exact same way its been done in CLI.  

```
$ ltc help
NAME:
   ltc - Command line interface for Lattice.
USAGE:
   ltc [global options] command [command options] [arguments...]
VERSION:
   development (not versioned)
AUTHOR(S):
   Pivotal <cf-lattice@lists.cloudfoundry.org>

COMMANDS:

  TARGET LATTICE:
    target, ta                Targets a lattice cluster

  CREATE AND MODIFY APPS:
    create, cr               Creates a docker app on lattice
    remove, rm            Stops and removes docker app(s) from lattice
    scale, sc                 Scales a docker app on lattice
    update-routes, ur   Updates the routes for a running app

  STREAM LOGS:
    logs, lo                    Streams logs from the specified application

  SEE WHATS RUNNING:
    cells, ce                  Shows details about lattice cells
    list, li, ls                   Lists applications running on lattice
    status, st                 Shows details about a running app on lattice
    visualize, vz            Shows a visualization of the workload distribution across the lattice cells

  ADVANCED:
    create-lrp, cl            Creates a docker app from JSON on lattice

  HELP AND DEBUG:
    debug-logs, dl         Streams logs from the lattice cluster components
    test, te                     Runs test suite against targeted lattice cluster
    help, h                     Shows a list of commands or help for one command

GLOBAL OPTIONS:
   --version, -v              Print the version
   --help, -h                  Show help

```

Looking forward for your feedback.  

As a side effect It also seems to solve the following stories in the pivotal tracker : :-)

[#93631582]
[#84348154]

PS: Original Author @ShwethaKumbla 
