### PR TITLE
break out cancel-task from delete-task

### DIFF
--- a/ltc/cli_app_factory/app_help.go
+++ b/ltc/cli_app_factory/app_help.go
@@ -86,6 +86,7 @@ func newAppPresenter(app *cli.App) (presenter appPresenter) {
 					presentCommand("submit-task"),
 					presentCommand("task"),
 					presentCommand("delete-task"),
+					presentCommand("cancel-task"),
 				},
 			},
 		}, {

--- a/ltc/cli_app_factory/cli_app_factory.go
+++ b/ltc/cli_app_factory/cli_app_factory.go
@@ -172,6 +172,7 @@ func cliCommands(ltcConfigRoot string, exitHandler exit_handler.ExitHandler, con
 		configCommandFactory.MakeTargetCommand(),
 		taskExaminerCommandFactory.MakeTaskCommand(),
 		taskRunnerCommandFactory.MakeDeleteTaskCommand(),
+		taskRunnerCommandFactory.MakeCancelTaskCommand(),
 		integrationTestCommandFactory.MakeIntegrationTestCommand(),
 		appRunnerCommandFactory.MakeUpdateRoutesCommand(),
 		appExaminerCommandFactory.MakeVisualizeCommand(),

--- a/ltc/task_runner/command_factory/task_runner_command_factory.go
+++ b/ltc/task_runner/command_factory/task_runner_command_factory.go
@@ -55,6 +55,18 @@ func (factory *TaskRunnerCommandFactory) MakeDeleteTaskCommand() cli.Command {
 	return taskDeleteCommand
 }
 
+func (factory *TaskRunnerCommandFactory) MakeCancelTaskCommand() cli.Command {
+	var taskDeleteCommand = cli.Command{
+		Name:        "cancel-task",
+		Aliases:     []string{"ct"},
+		Usage:       "Cancels the given task",
+		Description: "ltc cancel-task TASK_NAME",
+		Action:      factory.cancelTask,
+		Flags:       []cli.Flag{},
+	}
+	return taskDeleteCommand
+}
+
 func (factory *TaskRunnerCommandFactory) submitTask(context *cli.Context) {
 	filePath := context.Args().First()
 	if filePath == "" {
@@ -90,7 +102,25 @@ func (factory *TaskRunnerCommandFactory) deleteTask(context *cli.Context) {
 	err := factory.taskRunner.DeleteTask(taskGuid)
 	if err != nil {
 		factory.ui.Say("Error Deleting the task " + colors.Bold(taskGuid) + "\n")
-		factory.ui.Say("Failure Reason:" + colors.Red(err.Error()) + "\n")
+		factory.ui.Say("Failure Reason :" + colors.Red(err.Error()) + "\n")
+		factory.exitHandler.Exit(exit_codes.CommandFailed)
+		return
+	}
+	factory.ui.Say(colors.Green("OK"))
+}
+
+func (factory *TaskRunnerCommandFactory) cancelTask(context *cli.Context) {
+	taskGuid := context.Args().First()
+	if taskGuid == "" {
+		factory.ui.SayIncorrectUsage("Please input a valid TASK_GUID")
+		factory.exitHandler.Exit(exit_codes.InvalidSyntax)
+		return
+	}
+	factory.ui.Say("Cancelling the task " + colors.Bold(taskGuid) + "\n")
+	err := factory.taskRunner.CancelTask(taskGuid)
+	if err != nil {
+		factory.ui.Say("Error Cancelling the task " + colors.Bold(taskGuid) + "\n")
+		factory.ui.Say("Failure Reason :" + colors.Red(err.Error()) + "\n")
 		factory.exitHandler.Exit(exit_codes.CommandFailed)
 		return
 	}

--- a/ltc/task_runner/command_factory/task_runner_command_factory_test.go
+++ b/ltc/task_runner/command_factory/task_runner_command_factory_test.go
@@ -134,7 +134,7 @@ var _ = Describe("CommandFactory", func() {
 			Expect(outputBuffer).To(test_helpers.Say(colors.Green("OK")))
 		})
 
-		It("returns error while deleting the task", func() {
+		It("returns error when fail to delete the task", func() {
 			taskInfo := task_examiner.TaskInfo{
 				TaskGuid: "task-guid-1",
 				State:    "COMPLETED",
@@ -144,12 +144,53 @@ var _ = Describe("CommandFactory", func() {
 			test_helpers.ExecuteCommandWithArgs(deleteTaskCommand, []string{"task-guid-1"})
 
 			Expect(outputBuffer).To(test_helpers.Say("Error Deleting the task " + colors.Bold("task-guid-1")))
-			Expect(outputBuffer).To(test_helpers.Say("Failure Reason:" + colors.Red("task in unknown state")))
+			Expect(outputBuffer).To(test_helpers.Say("Failure Reason :" + colors.Red("task in unknown state")))
 			Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.CommandFailed}))
 		})
 
 		It("fails with usage", func() {
 			test_helpers.ExecuteCommandWithArgs(deleteTaskCommand, []string{})
+
+			Expect(outputBuffer).To(test_helpers.Say("Please input a valid TASK_GUID"))
+			Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.InvalidSyntax}))
+		})
+	})
+	Describe("CancelTaskCommand", func() {
+		var cancelTaskCommand cli.Command
+
+		BeforeEach(func() {
+			commandFactory := command_factory.NewTaskRunnerCommandFactory(fakeTaskRunner, terminalUI, fakeExitHandler)
+			cancelTaskCommand = commandFactory.MakeCancelTaskCommand()
+		})
+
+		It("Cancels the given task", func() {
+			taskInfo := task_examiner.TaskInfo{
+				TaskGuid: "task-guid-1",
+				State:    "COMPLETED",
+			}
+			fakeTaskExaminer.TaskStatusReturns(taskInfo, nil)
+			fakeTaskRunner.CancelTaskReturns(nil)
+			test_helpers.ExecuteCommandWithArgs(cancelTaskCommand, []string{"task-guid-1"})
+
+			Expect(outputBuffer).To(test_helpers.Say(colors.Green("OK")))
+		})
+
+		It("returns error when fail to cancel the task", func() {
+			taskInfo := task_examiner.TaskInfo{
+				TaskGuid: "task-guid-1",
+				State:    "COMPLETED",
+			}
+			fakeTaskExaminer.TaskStatusReturns(taskInfo, nil)
+			fakeTaskRunner.CancelTaskReturns(errors.New("task in unknown state"))
+			test_helpers.ExecuteCommandWithArgs(cancelTaskCommand, []string{"task-guid-1"})
+
+			Expect(outputBuffer).To(test_helpers.Say("Error Cancelling the task " + colors.Bold("task-guid-1")))
+			Expect(outputBuffer).To(test_helpers.Say("Failure Reason :" + colors.Red("task in unknown state")))
+			Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.CommandFailed}))
+		})
+
+		It("fails with usage", func() {
+			test_helpers.ExecuteCommandWithArgs(cancelTaskCommand, []string{})
 
 			Expect(outputBuffer).To(test_helpers.Say("Please input a valid TASK_GUID"))
 			Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.InvalidSyntax}))

--- a/ltc/task_runner/fake_task_runner/fake_task_runner.go
+++ b/ltc/task_runner/fake_task_runner/fake_task_runner.go
@@ -25,6 +25,14 @@ type FakeTaskRunner struct {
 	deleteTaskReturns struct {
 		result1 error
 	}
+	CancelTaskStub        func(taskGuid string) error
+	cancelTaskMutex       sync.RWMutex
+	cancelTaskArgsForCall []struct {
+		taskGuid string
+	}
+	cancelTaskReturns struct {
+		result1 error
+	}
 }
 
 func (fake *FakeTaskRunner) SubmitTask(submitTaskJson []byte) (string, error) {
@@ -88,6 +96,38 @@ func (fake *FakeTaskRunner) DeleteTaskArgsForCall(i int) string {
 func (fake *FakeTaskRunner) DeleteTaskReturns(result1 error) {
 	fake.DeleteTaskStub = nil
 	fake.deleteTaskReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeTaskRunner) CancelTask(taskGuid string) error {
+	fake.cancelTaskMutex.Lock()
+	fake.cancelTaskArgsForCall = append(fake.cancelTaskArgsForCall, struct {
+		taskGuid string
+	}{taskGuid})
+	fake.cancelTaskMutex.Unlock()
+	if fake.CancelTaskStub != nil {
+		return fake.CancelTaskStub(taskGuid)
+	} else {
+		return fake.cancelTaskReturns.result1
+	}
+}
+
+func (fake *FakeTaskRunner) CancelTaskCallCount() int {
+	fake.cancelTaskMutex.RLock()
+	defer fake.cancelTaskMutex.RUnlock()
+	return len(fake.cancelTaskArgsForCall)
+}
+
+func (fake *FakeTaskRunner) CancelTaskArgsForCall(i int) string {
+	fake.cancelTaskMutex.RLock()
+	defer fake.cancelTaskMutex.RUnlock()
+	return fake.cancelTaskArgsForCall[i].taskGuid
+}
+
+func (fake *FakeTaskRunner) CancelTaskReturns(result1 error) {
+	fake.CancelTaskStub = nil
+	fake.cancelTaskReturns = struct {
 		result1 error
 	}{result1}
 }


### PR DESCRIPTION
Added a command cancel-task to cancel task.
Modified delete-task command to delete only completed task.
Following are scenarios handled :- 
1. delete-task can only delete task if task is COMPLETED.
2. delete-task will return if task does not exist or if task name is null.
3. cancel-task will try to cancel task and  will return error if receptor return error while cancelling task.
4. if task is already COMPLETED , cancel-task will return success but will not go for task cancellation.
5. cancel-task will return error if task does not exist or if task name is null.
[#95422348]
