### PR TITLE
Update codegangsta-cli to fix ltc -v option

### DIFF
--- a/ltc/Godeps/Godeps.json
+++ b/ltc/Godeps/Godeps.json
@@ -33,8 +33,8 @@
 		},
 		{
 			"ImportPath": "github.com/codegangsta/cli",
-			"Comment": "1.2.0-115-g616b730",
-			"Rev": "616b730509ef3f11384d159cc52545639103ea86"
+			"Comment": "1.2.0-122-g8cbee4b",
+			"Rev": "8cbee4b7192cea690c9f048e742e6b4c3525fd9e"
 		},
 		{
 			"ImportPath": "github.com/docker/docker/api",

--- a/ltc/Godeps/_workspace/src/github.com/codegangsta/cli/.travis.yml
+++ b/ltc/Godeps/_workspace/src/github.com/codegangsta/cli/.travis.yml
@@ -1,5 +1,12 @@
 language: go
-go: 1.1
+sudo: false
+
+go:
+- 1.0.3
+- 1.1.2
+- 1.2.2
+- 1.3.3
+- 1.4.2
 
 script:
 - go vet ./...

--- a/ltc/Godeps/_workspace/src/github.com/codegangsta/cli/app.go
+++ b/ltc/Godeps/_workspace/src/github.com/codegangsta/cli/app.go
@@ -9,7 +9,7 @@ import (
 )
 
 // App is the main structure of a cli application. It is recomended that
-// and app be created with the cli.NewApp() function
+// an app be created with the cli.NewApp() function
 type App struct {
 	// The name of the program. Defaults to os.Args[0]
 	Name string

--- a/ltc/Godeps/_workspace/src/github.com/codegangsta/cli/app_test.go
+++ b/ltc/Godeps/_workspace/src/github.com/codegangsta/cli/app_test.go
@@ -718,6 +718,67 @@ func TestApp_Run_CommandWithSubcommandHasHelpTopic(t *testing.T) {
 	}
 }
 
+func TestApp_Run_Help(t *testing.T) {
+	var helpArguments = [][]string{{"boom", "--help"}, {"boom", "-h"}, {"boom", "help"}}
+
+	for _, args := range helpArguments {
+		buf := new(bytes.Buffer)
+
+		t.Logf("==> checking with arguments %v", args)
+
+		app := cli.NewApp()
+		app.Name = "boom"
+		app.Usage = "make an explosive entrance"
+		app.Writer = buf
+		app.Action = func(c *cli.Context) {
+			buf.WriteString("boom I say!")
+		}
+
+		err := app.Run(args)
+		if err != nil {
+			t.Error(err)
+		}
+
+		output := buf.String()
+		t.Logf("output: %q\n", buf.Bytes())
+
+		if !strings.Contains(output, "boom - make an explosive entrance") {
+			t.Errorf("want help to contain %q, did not: \n%q", "boom - make an explosive entrance", output)
+		}
+	}
+}
+
+func TestApp_Run_Version(t *testing.T) {
+	var versionArguments = [][]string{{"boom", "--version"}, {"boom", "-v"}}
+
+	for _, args := range versionArguments {
+		buf := new(bytes.Buffer)
+
+		t.Logf("==> checking with arguments %v", args)
+
+		app := cli.NewApp()
+		app.Name = "boom"
+		app.Usage = "make an explosive entrance"
+		app.Version = "0.1.0"
+		app.Writer = buf
+		app.Action = func(c *cli.Context) {
+			buf.WriteString("boom I say!")
+		}
+
+		err := app.Run(args)
+		if err != nil {
+			t.Error(err)
+		}
+
+		output := buf.String()
+		t.Logf("output: %q\n", buf.Bytes())
+
+		if !strings.Contains(output, "0.1.0") {
+			t.Errorf("want version to contain %q, did not: \n%q", "0.1.0", output)
+		}
+	}
+}
+
 func TestApp_Run_DoesNotOverwriteErrorFromBefore(t *testing.T) {
 	app := cli.NewApp()
 	app.Action = func(c *cli.Context) {}

--- a/ltc/Godeps/_workspace/src/github.com/codegangsta/cli/help.go
+++ b/ltc/Godeps/_workspace/src/github.com/codegangsta/cli/help.go
@@ -181,7 +181,7 @@ func printHelp(out io.Writer, templ string, data interface{}) {
 }
 
 func checkVersion(c *Context) bool {
-	if c.GlobalBool("version") {
+	if c.GlobalBool("version") || c.GlobalBool("v") || c.Bool("version") || c.Bool("v") {
 		ShowVersion(c)
 		return true
 	}
@@ -190,7 +190,7 @@ func checkVersion(c *Context) bool {
 }
 
 func checkHelp(c *Context) bool {
-	if c.GlobalBool("h") || c.GlobalBool("help") {
+	if c.GlobalBool("h") || c.GlobalBool("help") || c.Bool("h") || c.Bool("help") {
 		ShowAppHelp(c)
 		return true
 	}


### PR DESCRIPTION
[#96713540]

Now ltc version command gives expected output. Only needed the codegangsta cli to be updated.

```
$ltc -v
ltc version development (not versioned)
```

Address the issue mentioned in https://github.com/cloudfoundry-incubator/lattice/issues/138
