### PR TITLE
Tcp router cli updates

### DIFF
--- a/docs/ltc.md
+++ b/docs/ltc.md
@@ -106,6 +106,19 @@ The set of routes passed into `ltc update-routes` will *override* the existing s
 
 - **`--no-routes`** specifies that no routes be registered.
 
+### `ltc update`
+
+`ltc update APP_NAME [--http-routes HOST:CONTAINER_PORT[,...]] [--tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]]` updates attributes of an existing application.
+
+- **`--http-routes HOST:CONTAINER_PORT[,...]`**
+Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port.  Container ports must be among those specified on create with --ports or with the EXPOSE Docker image directive. Replaces all existing routes.
+
+- **`--tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]`**
+Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port.  Container ports must be among those specified on create with --ports or with the EXPOSE Docker image directive. Replaces all existing routes.
+
+- **`--no-routes`**
+Removes all existing routes. When this flag is provided, --http-routes and --tcp-routes will be ignored if they are also provided.
+
 ## Building and Launching Droplets
 
 **Note**: Buildpack support requires a Droplet Store, which is automatically configured when you run `ltc target`. You can validate that the Droplet store has been automatically detected by running `ltc target`. If Buildpack support is working correctly, you'll see two lines of output:

--- a/docs/ltc.md
+++ b/docs/ltc.md
@@ -58,17 +58,24 @@ By default, `ltc` requests that Lattice open up all ports specified by the `EXPO
 
 You can modify all of this behavior from the command line:
 
-- **`--ports=8080,9000`** allows you to specify the set of ports to open on the container.  This overrides any `EXPOSE` directives associated with the Docker image.  
+- **`--ports=8080,9000,6379,6000`** allows you to specify the set of ports to open on the container.  This overrides any `EXPOSE` directives associated with the Docker image.
     - When specifying multiple ports via `--port` you should also specify a `--monitor-port` or `--monitor-url` to perform the healthcheck on (or, alternatively, turn off the health-check via `--no-monitor`).
-- **`--routes=8080:my-app,9000:my-app-admin`** allows you to specify the routes to map to the requested ports.  In this example, `my-app.192.168.11.11.xip.io` will map to port `8080` and `my-app-admin.192.168.11.11.xip.io` will map to port `9000`.
-  - You can comma-delimit multiple routes to the same port (e.g. `--routes=8080:my-app,8080:my-app-alias`).
-- **`--no-routes`** allows you to specify that no routes be registered. 
-- **`--tcp-routes=6379:50000,6000:50001`** allows you to specify external ports that will be routed to container ports. In this example, given a TCP router at 192.168.11.11, then 192.168.11.11:50000 will be routed to port container port 6379, and 192.168.11.11:50001 will be routed to container port 6000. As Lattice assigned container ports starting at 60000, and the router runs on the same IP as the app container, choose an external port below 60000. You can map multiple external ports to the same container port (e.g. --tcp-routes=6379:50000,6379:50001).
+
+    NOTE: Container ports provided with --http-routes and --tcp-routes must be among the container ports specified with --ports.
+
+- **`--http-routes=my-app:8080,my-app-admin:9000`** allows you to specify the routes to map to the requested ports.  In this example, `my-app.192.168.11.11.xip.io` on port 80 will map to port `8080` and `my-app-admin.192.168.11.11.xip.io` on port 80 will map to port `9000`.
+  - You can comma-delimit multiple routes to the same port (e.g. `--http-routes=my-app:8080,my-app-alias:8080`).
+
+
+- **`--tcp-routes=50000:6379,50001:6000,`** allows you to specify external ports that will be routed to container ports. In this example, given a TCP router at 192.168.11.11, then 192.168.11.11:50000 will be routed to port container port 6379, and 192.168.11.11:50001 will be routed to container port 6000. As Lattice assigned container ports starting at 60000, and the router runs on the same IP as the app container, choose an external port below 60000. You can map multiple external ports to the same container port (e.g. --tcp-routes=50000:6379,50001:6000).
+
+- **`--no-routes`** allows you to specify that no routes be registered.
+
 
 
 #### Managing Healthchecks
 
-In addition, `ltc` sets up a healthcheck that verifies the application responds on a given port or to a specified HTTP request. 
+In addition, `ltc` sets up a healthcheck that verifies the application responds on a given port or to a specified HTTP request.
 
 By default, `ltc` selects the *lowest* exposed port to healthcheck against;  if no monitoring options are specified, 8080 is the default unless `--no-monitor` is set.
 
@@ -83,10 +90,10 @@ By default, `ltc` selects the *lowest* exposed port to healthcheck against;  if 
 
 `ltc remove APP1_NAME [APP2_NAME APP3_NAME...]` removes the specified applications from a Lattice deployment.  
 
-- This operation is performed in the background. `ltc list` may still show the app as running immediately after running `ltc remove`. 
+- This operation is performed in the background. `ltc list` may still show the app as running immediately after running `ltc remove`.
 - To stop an application without removing it, try `ltc scale APP_NAME 0`.
 
-### `ltc scale` 
+### `ltc scale`
 
 `ltc scale APP_NAME NUM_INSTANCES` modifies the number of running instances of an application.
 
@@ -94,11 +101,11 @@ By default, `ltc` selects the *lowest* exposed port to healthcheck against;  if 
 
 ### `ltc update-routes`
 
-`ltc update-routes APP_NAME PORT:ROUTE,PORT:ROUTE,...` allows you to update the routes associated with an application *after* it has been deployed.  The format is identical to the `--routes` option on `ltc create`. 
+`ltc update-routes APP_NAME PORT:ROUTE,PORT:ROUTE,...` allows you to update the routes associated with an application *after* it has been deployed.  The format is identical to the `--routes` option on `ltc create`.
 
 The set of routes passed into `ltc update-routes` will *override* the existing set of routes - these modification will start working shortly after the call to `update-routes`.
 
-- **`--no-routes`** specifies that no routes be registered. 
+- **`--no-routes`** specifies that no routes be registered.
 
 ## Building and Launching Droplets
 
@@ -120,7 +127,7 @@ Lattice has the ability to build and run droplets generated by CF Buildpacks. Bo
 - **`--timeout=2m`** sets the maximum polling duration for building the droplet.
 
   As an alternative to specifying the URL for a given Buildpack, we also support the following aliases: go, java, python, ruby, nodejs, php, binary, or staticfile.
-  
+
   If the application directory contains a `.cfignore` file, `build-droplet` will not upload files that match the contents of the `.cfignore` file.
 
 ### `ltc launch-droplet`
@@ -128,7 +135,7 @@ Lattice has the ability to build and run droplets generated by CF Buildpacks. Bo
 `ltc launch-droplet APP_NAME DROPLET_NAME` launches a droplet as an app running on lattice
 
    `ltc launch-droplet` has the same options as [`ltc create`](/docs/ltc.md#ltc-create), except for `--run-as-root`.  Droplets are run as the user `vcap`.
-   
+
    Finally, one can override the default start command by specifiying a start command after a `--` separator.  This can be followed by any arguments one wishes to pass to the app.  For example:
 
     ltc launch-droplet lattice-app lattice-app -- /lattice-app -quiet=true
@@ -236,4 +243,3 @@ This indicates that instance 0 of the application has been `RUNNING` on `lattice
 `ltc debug-logs` streams back logs from some of Lattice's key components.  This is useful for debugging situations where containers fail to get created/torn down.
 
 - **`--raw`** prints the cluster logs with no styling.
-

--- a/docs/ltc.md
+++ b/docs/ltc.md
@@ -63,14 +63,13 @@ You can modify all of this behavior from the command line:
 
     NOTE: Container ports provided with --http-routes and --tcp-routes must be among the container ports specified with --ports.
 
-- **`--http-routes=my-app:8080,my-app-admin:9000`** allows you to specify the routes to map to the requested ports.  In this example, `my-app.192.168.11.11.xip.io` on port 80 will map to port `8080` and `my-app-admin.192.168.11.11.xip.io` on port 80 will map to port `9000`.
-  - You can comma-delimit multiple routes to the same port (e.g. `--http-routes=my-app:8080,my-app-alias:8080`).
+- **`--http-routes HOST:CONTAINER_PORT[,...]`**
+    - Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port. Container ports must be among those specified with --ports or with the EXPOSE Docker image directive.
 
-
-- **`--tcp-routes=50000:6379,50001:6000,`** allows you to specify external ports that will be routed to container ports. In this example, given a TCP router at 192.168.11.11, then 192.168.11.11:50000 will be routed to port container port 6379, and 192.168.11.11:50001 will be routed to container port 6000. As Lattice assigned container ports starting at 60000, and the router runs on the same IP as the app container, choose an external port below 60000. You can map multiple external ports to the same container port (e.g. --tcp-routes=50000:6379,50001:6000).
+- **`--tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]`**
+    - Requests for the provided external port will be forwarded to the associated container port. Container ports must be among those specified with --ports or with the EXPOSE Docker image directive.
 
 - **`--no-routes`** allows you to specify that no routes be registered.
-
 
 
 #### Managing Healthchecks

--- a/ltc/app_examiner/app_examiner.go
+++ b/ltc/app_examiner/app_examiner.go
@@ -25,7 +25,7 @@ type AppInfo struct {
 	MemoryMB               int
 	CPUWeight              uint
 	Ports                  []uint16
-	Routes                 route_helpers.AppRoutes
+	Routes                 route_helpers.Routes
 	LogGuid                string
 	LogSource              string
 	Annotation             string
@@ -256,7 +256,7 @@ func mergeDesiredActualLRPs(desiredLRPs []receptor.DesiredLRPResponse, actualLRP
 			MemoryMB:               desiredLRP.MemoryMB,
 			CPUWeight:              desiredLRP.CPUWeight,
 			Ports:                  desiredLRP.Ports,
-			Routes:                 route_helpers.AppRoutesFromRoutingInfo(desiredLRP.Routes),
+			Routes:                 route_helpers.RoutesFromRoutingInfo(desiredLRP.Routes),
 			LogGuid:                desiredLRP.LogGuid,
 			LogSource:              desiredLRP.LogSource,
 			Annotation:             desiredLRP.Annotation,

--- a/ltc/app_examiner/command_factory/app_examiner_command_factory_test.go
+++ b/ltc/app_examiner/command_factory/app_examiner_command_factory_test.go
@@ -40,6 +40,7 @@ var _ = Describe("CommandFactory", func() {
 		fakeExitHandler         *fake_exit_handler.FakeExitHandler
 		fakeGraphicalVisualizer *fake_graphical_visualizer.FakeGraphicalVisualizer
 		fakeTaskExaminer        *fake_task_examiner.FakeTaskExaminer
+		systemDomain            string
 	)
 
 	BeforeEach(func() {
@@ -53,13 +54,14 @@ var _ = Describe("CommandFactory", func() {
 		fakeClock = fakeclock.NewFakeClock(time.Date(2012, time.February, 29, 6, 45, 30, 820, location))
 		fakeExitHandler = &fake_exit_handler.FakeExitHandler{}
 		fakeGraphicalVisualizer = &fake_graphical_visualizer.FakeGraphicalVisualizer{}
+		systemDomain = "system.domain"
 	})
 
 	Describe("ListAppsCommand", func() {
 		var listAppsCommand cli.Command
 
 		BeforeEach(func() {
-			commandFactory := command_factory.NewAppExaminerCommandFactory(fakeAppExaminer, terminalUI, fakeClock, fakeExitHandler, nil, fakeTaskExaminer)
+			commandFactory := command_factory.NewAppExaminerCommandFactory(fakeAppExaminer, terminalUI, fakeClock, fakeExitHandler, nil, fakeTaskExaminer, systemDomain)
 			listAppsCommand = commandFactory.MakeListAppCommand()
 		})
 
@@ -72,10 +74,12 @@ var _ = Describe("CommandFactory", func() {
 					DiskMB:                 100,
 					MemoryMB:               50,
 					Ports:                  []uint16{54321},
-					Routes: route_helpers.AppRoutes{
-						route_helpers.AppRoute{
-							Hostnames: []string{"alldaylong.com"},
-							Port:      54321,
+					Routes: route_helpers.Routes{
+						AppRoutes: route_helpers.AppRoutes{
+							route_helpers.AppRoute{
+								Hostnames: []string{"alldaylong.com"},
+								Port:      54321,
+							},
 						},
 					},
 				},
@@ -86,10 +90,12 @@ var _ = Describe("CommandFactory", func() {
 					DiskMB:                 400,
 					MemoryMB:               30,
 					Ports:                  []uint16{1234},
-					Routes: route_helpers.AppRoutes{
-						route_helpers.AppRoute{
-							Hostnames: []string{"never.io"},
-							Port:      1234,
+					Routes: route_helpers.Routes{
+						AppRoutes: route_helpers.AppRoutes{
+							route_helpers.AppRoute{
+								Hostnames: []string{"never.io"},
+								Port:      1234,
+							},
 						},
 					},
 				},
@@ -100,10 +106,12 @@ var _ = Describe("CommandFactory", func() {
 					DiskMB:                 600,
 					MemoryMB:               90,
 					Ports:                  []uint16{1234},
-					Routes: route_helpers.AppRoutes{
-						route_helpers.AppRoute{
-							Hostnames: []string{"allthetime.com", "herewego.org"},
-							Port:      1234,
+					Routes: route_helpers.Routes{
+						AppRoutes: route_helpers.AppRoutes{
+							route_helpers.AppRoute{
+								Hostnames: []string{"allthetime.com", "herewego.org"},
+								Port:      1234,
+							},
 						},
 					},
 				},
@@ -113,7 +121,7 @@ var _ = Describe("CommandFactory", func() {
 					ActualRunningInstances: 0,
 					DiskMB:                 10,
 					MemoryMB:               10,
-					Routes:                 route_helpers.AppRoutes{},
+					Routes:                 route_helpers.Routes{},
 				},
 			}
 			fakeAppExaminer.ListAppsReturns(listApps, nil)
@@ -169,7 +177,7 @@ var _ = Describe("CommandFactory", func() {
 			Expect(outputBuffer).To(test_helpers.Say(colors.Green("5/5")))
 			Expect(outputBuffer).To(test_helpers.Say(colors.NoColor("600")))
 			Expect(outputBuffer).To(test_helpers.Say(colors.NoColor("90")))
-			Expect(outputBuffer).To(test_helpers.Say("allthetime.com, herewego.org => 1234"))
+			Expect(outputBuffer).To(test_helpers.Say("allthetime.com => 1234, herewego.org => 1234"))
 
 			Expect(outputBuffer).To(test_helpers.Say(colors.Bold("process4")))
 			Expect(outputBuffer).To(test_helpers.Say(colors.Green("0/0")))
@@ -256,10 +264,12 @@ var _ = Describe("CommandFactory", func() {
 						DiskMB:                 100,
 						MemoryMB:               50,
 						Ports:                  []uint16{54321},
-						Routes: route_helpers.AppRoutes{
-							route_helpers.AppRoute{
-								Hostnames: []string{"alldaylong.com"},
-								Port:      54321,
+						Routes: route_helpers.Routes{
+							AppRoutes: route_helpers.AppRoutes{
+								route_helpers.AppRoute{
+									Hostnames: []string{"alldaylong.com"},
+									Port:      54321,
+								},
 							},
 						},
 					},
@@ -285,13 +295,168 @@ var _ = Describe("CommandFactory", func() {
 				Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.CommandFailed}))
 			})
 		})
+
+		Context("when app has tcp routes", func() {
+			It("displays all tcp routes along with http routes", func() {
+				listApps := []app_examiner.AppInfo{
+					app_examiner.AppInfo{
+						ProcessGuid:            "process1",
+						DesiredInstances:       21,
+						ActualRunningInstances: 0,
+						DiskMB:                 100,
+						MemoryMB:               50,
+						Ports:                  []uint16{54321, 5222},
+						Routes: route_helpers.Routes{
+							AppRoutes: route_helpers.AppRoutes{
+								route_helpers.AppRoute{
+									Hostnames: []string{"alldaylong.com"},
+									Port:      54321,
+								},
+							},
+							TcpRoutes: route_helpers.TcpRoutes{
+								route_helpers.TcpRoute{
+									ExternalPort: 51000,
+									Port:         5222,
+								},
+							},
+						},
+					},
+					app_examiner.AppInfo{
+						ProcessGuid:            "process2",
+						DesiredInstances:       8,
+						ActualRunningInstances: 9,
+						DiskMB:                 400,
+						MemoryMB:               30,
+						Ports:                  []uint16{1234, 7400},
+						Routes: route_helpers.Routes{
+							AppRoutes: route_helpers.AppRoutes{
+								route_helpers.AppRoute{
+									Hostnames: []string{"never.io"},
+									Port:      1234,
+								},
+							},
+							TcpRoutes: route_helpers.TcpRoutes{
+								route_helpers.TcpRoute{
+									ExternalPort: 52000,
+									Port:         7400,
+								},
+							},
+						},
+					},
+					app_examiner.AppInfo{
+						ProcessGuid:            "process3",
+						DesiredInstances:       5,
+						ActualRunningInstances: 5,
+						DiskMB:                 600,
+						MemoryMB:               90,
+						Ports:                  []uint16{1234, 1883},
+						Routes: route_helpers.Routes{
+							AppRoutes: route_helpers.AppRoutes{
+								route_helpers.AppRoute{
+									Hostnames: []string{"allthetime.com", "herewego.org"},
+									Port:      1234,
+								},
+							},
+							TcpRoutes: route_helpers.TcpRoutes{
+								route_helpers.TcpRoute{
+									ExternalPort: 53000,
+									Port:         1883,
+								},
+							},
+						},
+					},
+					app_examiner.AppInfo{
+						ProcessGuid:            "process4",
+						DesiredInstances:       0,
+						ActualRunningInstances: 0,
+						DiskMB:                 10,
+						MemoryMB:               10,
+						Routes:                 route_helpers.Routes{},
+					},
+				}
+				fakeAppExaminer.ListAppsReturns(listApps, nil)
+
+				test_helpers.ExecuteCommandWithArgs(listAppsCommand, []string{})
+
+				Expect(outputBuffer).To(test_helpers.Say(colors.Bold("process1")))
+				Expect(outputBuffer).To(test_helpers.Say("alldaylong.com => 54321, system.domain:51000 => 5222"))
+
+				Expect(outputBuffer).To(test_helpers.Say(colors.Bold("process2")))
+				Expect(outputBuffer).To(test_helpers.Say("never.io => 1234, system.domain:52000 => 7400"))
+
+				Expect(outputBuffer).To(test_helpers.Say(colors.Bold("process3")))
+				Expect(outputBuffer).To(test_helpers.Say("allthetime.com => 1234, herewego.org => 1234, system.domain:53000 => 1883"))
+
+				Expect(outputBuffer).To(test_helpers.Say(colors.Bold("process4")))
+			})
+		})
+
+		Context("when app has routes with container ports not listed in ports section", func() {
+			It("displays all tcp routes along with http routes", func() {
+				listApps := []app_examiner.AppInfo{
+					app_examiner.AppInfo{
+						ProcessGuid:            "process1",
+						DesiredInstances:       21,
+						ActualRunningInstances: 0,
+						DiskMB:                 100,
+						MemoryMB:               50,
+						Ports:                  []uint16{54321},
+						Routes: route_helpers.Routes{
+							AppRoutes: route_helpers.AppRoutes{
+								route_helpers.AppRoute{
+									Hostnames: []string{"alldaylong.com"},
+									Port:      54321,
+								},
+							},
+							TcpRoutes: route_helpers.TcpRoutes{
+								route_helpers.TcpRoute{
+									ExternalPort: 51000,
+									Port:         5222,
+								},
+							},
+						},
+					},
+					app_examiner.AppInfo{
+						ProcessGuid:            "process2",
+						DesiredInstances:       8,
+						ActualRunningInstances: 9,
+						DiskMB:                 400,
+						MemoryMB:               30,
+						Ports:                  []uint16{7400},
+						Routes: route_helpers.Routes{
+							AppRoutes: route_helpers.AppRoutes{
+								route_helpers.AppRoute{
+									Hostnames: []string{"never.io"},
+									Port:      1234,
+								},
+							},
+							TcpRoutes: route_helpers.TcpRoutes{
+								route_helpers.TcpRoute{
+									ExternalPort: 52000,
+									Port:         7400,
+								},
+							},
+						},
+					},
+				}
+				fakeAppExaminer.ListAppsReturns(listApps, nil)
+
+				test_helpers.ExecuteCommandWithArgs(listAppsCommand, []string{})
+
+				Expect(outputBuffer).To(test_helpers.Say(colors.Bold("process1")))
+				Expect(outputBuffer).To(test_helpers.Say("alldaylong.com => 54321"))
+
+				Expect(outputBuffer).To(test_helpers.Say(colors.Bold("process2")))
+				Expect(outputBuffer).To(test_helpers.Say("system.domain:52000 => 7400"))
+			})
+		})
 	})
 
 	Describe("VisualizeCommand", func() {
 		var visualizeCommand cli.Command
 
 		BeforeEach(func() {
-			commandFactory := command_factory.NewAppExaminerCommandFactory(fakeAppExaminer, terminalUI, fakeClock, fakeExitHandler, fakeGraphicalVisualizer, fakeTaskExaminer)
+			commandFactory := command_factory.NewAppExaminerCommandFactory(fakeAppExaminer, terminalUI, fakeClock, fakeExitHandler, fakeGraphicalVisualizer, fakeTaskExaminer, systemDomain)
 			visualizeCommand = commandFactory.MakeVisualizeCommand()
 		})
 
@@ -444,7 +609,7 @@ var _ = Describe("CommandFactory", func() {
 		}
 
 		BeforeEach(func() {
-			commandFactory := command_factory.NewAppExaminerCommandFactory(fakeAppExaminer, terminalUI, fakeClock, fakeExitHandler, nil, fakeTaskExaminer)
+			commandFactory := command_factory.NewAppExaminerCommandFactory(fakeAppExaminer, terminalUI, fakeClock, fakeExitHandler, nil, fakeTaskExaminer, systemDomain)
 			statusCommand = commandFactory.MakeStatusCommand()
 
 			sampleAppInfo = app_examiner.AppInfo{
@@ -460,14 +625,16 @@ var _ = Describe("CommandFactory", func() {
 				MemoryMB:     256,
 				CPUWeight:    100,
 				Ports:        []uint16{8887, 9000},
-				Routes: route_helpers.AppRoutes{
-					route_helpers.AppRoute{
-						Port:      9090,
-						Hostnames: []string{"route-me.my-fun-domain.com"},
-					},
-					route_helpers.AppRoute{
-						Port:      8080,
-						Hostnames: []string{"wompy-app.my-fun-domain.com", "cranky-app.my-fun-domain.com"},
+				Routes: route_helpers.Routes{
+					AppRoutes: route_helpers.AppRoutes{
+						route_helpers.AppRoute{
+							Port:      9090,
+							Hostnames: []string{"route-me.my-fun-domain.com"},
+						},
+						route_helpers.AppRoute{
+							Port:      8080,
+							Hostnames: []string{"wompy-app.my-fun-domain.com", "cranky-app.my-fun-domain.com"},
+						},
 					},
 				},
 				LogGuid:    "a9s8dfa99023r",
@@ -793,7 +960,7 @@ var _ = Describe("CommandFactory", func() {
 		var cellsCommand cli.Command
 
 		BeforeEach(func() {
-			commandFactory := command_factory.NewAppExaminerCommandFactory(fakeAppExaminer, terminalUI, fakeClock, fakeExitHandler, nil, fakeTaskExaminer)
+			commandFactory := command_factory.NewAppExaminerCommandFactory(fakeAppExaminer, terminalUI, fakeClock, fakeExitHandler, nil, fakeTaskExaminer, systemDomain)
 			cellsCommand = commandFactory.MakeCellsCommand()
 		})
 

--- a/ltc/app_runner/app_runner.go
+++ b/ltc/app_runner/app_runner.go
@@ -198,7 +198,7 @@ func (appRunner *appRunner) buildRoutes(params CreateAppParams, primaryPort uint
 				Port:      port,
 			})
 		}
-	} else {
+	} else if len(params.TcpRoutes) == 0 {
 		appRoutes = appRunner.buildDefaultRoutingInfo(params.Name, params.ExposedPorts, primaryPort)
 	}
 

--- a/ltc/app_runner/app_runner_test.go
+++ b/ltc/app_runner/app_runner_test.go
@@ -221,17 +221,7 @@ var _ = Describe("AppRunner", func() {
 						},
 					))
 
-					Expect(routes.AppRoutes).To(ContainExactly(
-						route_helpers.AppRoutes{
-							route_helpers.AppRoute{
-								Hostnames: []string{"americano-app.myDiegoInstall.com", "americano-app-2000.myDiegoInstall.com"},
-								Port:      2000,
-							},
-							route_helpers.AppRoute{
-								Hostnames: []string{"americano-app-4000.myDiegoInstall.com"},
-								Port:      4000,
-							},
-						}))
+					Expect(routes.AppRoutes).To(BeNil())
 				})
 			})
 		})
@@ -274,8 +264,10 @@ var _ = Describe("AppRunner", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				Expect(fakeReceptorClient.CreateDesiredLRPCallCount()).To(Equal(1))
-				appRoutes := route_helpers.AppRoutesFromRoutingInfo(fakeReceptorClient.CreateDesiredLRPArgsForCall(0).Routes)
-				Expect(appRoutes).To(ContainExactly(
+
+				routes := route_helpers.RoutesFromRoutingInfo(fakeReceptorClient.CreateDesiredLRPArgsForCall(0).Routes)
+
+				Expect(routes.AppRoutes).To(ContainExactly(
 					route_helpers.AppRoutes{
 						route_helpers.AppRoute{
 							Hostnames: []string{"wiggle.myDiegoInstall.com", "swang.myDiegoInstall.com"},
@@ -286,6 +278,7 @@ var _ = Describe("AppRunner", func() {
 							Port:      4000,
 						},
 					}))
+				Expect(routes.TcpRoutes).To(BeNil())
 			})
 		})
 

--- a/ltc/app_runner/app_runner_test.go
+++ b/ltc/app_runner/app_runner_test.go
@@ -732,6 +732,266 @@ var _ = Describe("AppRunner", func() {
 		})
 	})
 
+	Describe("UpdateApp", func() {
+
+		Context("when http routes are updated", func() {
+			It("updates the Routes", func() {
+				desiredLRPs := []receptor.DesiredLRPResponse{
+					receptor.DesiredLRPResponse{ProcessGuid: "test-app"},
+				}
+				fakeReceptorClient.DesiredLRPsReturns(desiredLRPs, nil)
+				expectedRouteOverrides := app_runner.RouteOverrides{
+					app_runner.RouteOverride{
+						HostnamePrefix: "foo.com",
+						Port:           8080,
+					},
+					app_runner.RouteOverride{
+						HostnamePrefix: "bar.com",
+						Port:           9090,
+					},
+				}
+				updateAppParams := app_runner.UpdateAppParams{
+					Name:           "test-app",
+					RouteOverrides: expectedRouteOverrides,
+				}
+
+				err := appRunner.UpdateApp(updateAppParams)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeReceptorClient.UpdateDesiredLRPCallCount()).To(Equal(1))
+				processGuid, updateRequest := fakeReceptorClient.UpdateDesiredLRPArgsForCall(0)
+				Expect(processGuid).To(Equal("test-app"))
+				expectedRoutes := route_helpers.AppRoutes{
+					route_helpers.AppRoute{Hostnames: []string{"foo.com.myDiegoInstall.com"}, Port: 8080},
+					route_helpers.AppRoute{Hostnames: []string{"bar.com.myDiegoInstall.com"}, Port: 9090},
+				}
+				routes := route_helpers.RoutesFromRoutingInfo(updateRequest.Routes)
+				Expect(routes.AppRoutes).To(ContainExactly(expectedRoutes))
+				Expect(routes.TcpRoutes).To(BeNil())
+			})
+		})
+
+		Context("when tcp routes are updated", func() {
+			It("updates the Routes", func() {
+				desiredLRPs := []receptor.DesiredLRPResponse{
+					receptor.DesiredLRPResponse{ProcessGuid: "test-app"},
+				}
+				fakeReceptorClient.DesiredLRPsReturns(desiredLRPs, nil)
+				expectedTcpRoutes := app_runner.TcpRoutes{
+					app_runner.TcpRoute{
+						ExternalPort: 51000,
+						Port:         8080,
+					},
+					app_runner.TcpRoute{
+						ExternalPort: 52000,
+						Port:         9090,
+					},
+				}
+				updateAppParams := app_runner.UpdateAppParams{
+					Name:      "test-app",
+					TcpRoutes: expectedTcpRoutes,
+				}
+
+				err := appRunner.UpdateApp(updateAppParams)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeReceptorClient.UpdateDesiredLRPCallCount()).To(Equal(1))
+				processGuid, updateRequest := fakeReceptorClient.UpdateDesiredLRPArgsForCall(0)
+				Expect(processGuid).To(Equal("test-app"))
+				expectedRoutes := route_helpers.TcpRoutes{
+					route_helpers.TcpRoute{ExternalPort: 51000, Port: 8080},
+					route_helpers.TcpRoute{ExternalPort: 52000, Port: 9090},
+				}
+				routes := route_helpers.RoutesFromRoutingInfo(updateRequest.Routes)
+				Expect(routes.TcpRoutes).To(ContainExactly(expectedRoutes))
+				Expect(routes.AppRoutes).To(BeNil())
+			})
+		})
+
+		Context("when both http and tcp routes are updated", func() {
+			It("updates the Routes", func() {
+				desiredLRPs := []receptor.DesiredLRPResponse{
+					receptor.DesiredLRPResponse{ProcessGuid: "test-app"},
+				}
+				fakeReceptorClient.DesiredLRPsReturns(desiredLRPs, nil)
+				expectedRouteOverrides := app_runner.RouteOverrides{
+					app_runner.RouteOverride{
+						HostnamePrefix: "foo.com",
+						Port:           8080,
+					},
+					app_runner.RouteOverride{
+						HostnamePrefix: "bar.com",
+						Port:           9090,
+					},
+				}
+				expectedTcpRoutes := app_runner.TcpRoutes{
+					app_runner.TcpRoute{
+						ExternalPort: 51000,
+						Port:         5222,
+					},
+					app_runner.TcpRoute{
+						ExternalPort: 52000,
+						Port:         6379,
+					},
+				}
+				updateAppParams := app_runner.UpdateAppParams{
+					Name:           "test-app",
+					TcpRoutes:      expectedTcpRoutes,
+					RouteOverrides: expectedRouteOverrides,
+				}
+
+				err := appRunner.UpdateApp(updateAppParams)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeReceptorClient.UpdateDesiredLRPCallCount()).To(Equal(1))
+				processGuid, updateRequest := fakeReceptorClient.UpdateDesiredLRPArgsForCall(0)
+				Expect(processGuid).To(Equal("test-app"))
+
+				expectedAppRoutes := route_helpers.AppRoutes{
+					route_helpers.AppRoute{Hostnames: []string{"foo.com.myDiegoInstall.com"}, Port: 8080},
+					route_helpers.AppRoute{Hostnames: []string{"bar.com.myDiegoInstall.com"}, Port: 9090},
+				}
+				expectedRoutes := route_helpers.TcpRoutes{
+					route_helpers.TcpRoute{ExternalPort: 51000, Port: 5222},
+					route_helpers.TcpRoute{ExternalPort: 52000, Port: 6379},
+				}
+
+				routes := route_helpers.RoutesFromRoutingInfo(updateRequest.Routes)
+				Expect(routes.TcpRoutes).To(ContainExactly(expectedRoutes))
+				Expect(routes.AppRoutes).To(ContainExactly(expectedAppRoutes))
+			})
+		})
+
+		Context("when no routes is true", func() {
+			It("deregisters all the routes", func() {
+				desiredLRPs := []receptor.DesiredLRPResponse{
+					receptor.DesiredLRPResponse{ProcessGuid: "test-app"},
+				}
+				fakeReceptorClient.DesiredLRPsReturns(desiredLRPs, nil)
+				expectedRouteOverrides := app_runner.RouteOverrides{
+					app_runner.RouteOverride{
+						HostnamePrefix: "foo.com",
+						Port:           8080,
+					},
+					app_runner.RouteOverride{
+						HostnamePrefix: "bar.com",
+						Port:           9090,
+					},
+				}
+				expectedTcpRoutes := app_runner.TcpRoutes{
+					app_runner.TcpRoute{
+						ExternalPort: 51000,
+						Port:         5222,
+					},
+					app_runner.TcpRoute{
+						ExternalPort: 52000,
+						Port:         6379,
+					},
+				}
+				updateAppParams := app_runner.UpdateAppParams{
+					Name:           "test-app",
+					TcpRoutes:      expectedTcpRoutes,
+					RouteOverrides: expectedRouteOverrides,
+					NoRoutes:       true,
+				}
+
+				err := appRunner.UpdateApp(updateAppParams)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeReceptorClient.UpdateDesiredLRPCallCount()).To(Equal(1))
+				processGuid, updateRequest := fakeReceptorClient.UpdateDesiredLRPArgsForCall(0)
+				Expect(processGuid).To(Equal("test-app"))
+				Expect(updateRequest.Routes).To(Equal(route_helpers.Routes{AppRoutes: route_helpers.AppRoutes{}}.RoutingInfo()))
+			})
+		})
+
+		Context("when an empty routes is passed", func() {
+			It("deregisters the routes", func() {
+				desiredLRPs := []receptor.DesiredLRPResponse{receptor.DesiredLRPResponse{ProcessGuid: "test-app"}}
+				fakeReceptorClient.DesiredLRPsReturns(desiredLRPs, nil)
+
+				updateAppParams := app_runner.UpdateAppParams{
+					Name: "test-app",
+				}
+
+				err := appRunner.UpdateApp(updateAppParams)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(fakeReceptorClient.UpdateDesiredLRPCallCount()).To(Equal(1))
+				processGuid, updateRequest := fakeReceptorClient.UpdateDesiredLRPArgsForCall(0)
+				Expect(processGuid).To(Equal("test-app"))
+				Expect(updateRequest.Routes).To(Equal(route_helpers.Routes{}.RoutingInfo()))
+			})
+		})
+
+		Context("when app is not started", func() {
+			It("returns errors", func() {
+				expectedRouteOverrides := app_runner.RouteOverrides{
+					app_runner.RouteOverride{
+						HostnamePrefix: "foo.com",
+						Port:           8080,
+					},
+					app_runner.RouteOverride{
+						HostnamePrefix: "bar.com",
+						Port:           9090,
+					},
+				}
+				desiredLRPs := []receptor.DesiredLRPResponse{receptor.DesiredLRPResponse{ProcessGuid: "test-app"}}
+				fakeReceptorClient.DesiredLRPsReturns(desiredLRPs, nil)
+
+				updateAppParams := app_runner.UpdateAppParams{
+					Name:           "app-not-running",
+					RouteOverrides: expectedRouteOverrides,
+				}
+
+				err := appRunner.UpdateApp(updateAppParams)
+				Expect(err).To(MatchError("app-not-running is not started."))
+				Expect(fakeReceptorClient.DesiredLRPsCallCount()).To(Equal(1))
+			})
+		})
+
+		Context("returning errors from the receptor", func() {
+			It("returns desiring lrp errors", func() {
+				desiredLRPs := []receptor.DesiredLRPResponse{receptor.DesiredLRPResponse{
+					ProcessGuid: "test-app", Instances: 1},
+				}
+				fakeReceptorClient.DesiredLRPsReturns(desiredLRPs, nil)
+				receptorError := errors.New("error - Updating an LRP")
+				fakeReceptorClient.UpdateDesiredLRPReturns(receptorError)
+
+				expectedRouteOverrides := app_runner.RouteOverrides{
+					app_runner.RouteOverride{
+						HostnamePrefix: "foo.com",
+						Port:           8080,
+					},
+					app_runner.RouteOverride{
+						HostnamePrefix: "bar.com",
+						Port:           9090,
+					},
+				}
+				updateAppParams := app_runner.UpdateAppParams{
+					Name:           "test-app",
+					RouteOverrides: expectedRouteOverrides,
+				}
+
+				err := appRunner.UpdateApp(updateAppParams)
+				Expect(err).To(MatchError(receptorError))
+			})
+
+			It("returns errors fetching the existing lrp count", func() {
+				receptorError := errors.New("error - Existing Count")
+				fakeReceptorClient.DesiredLRPsReturns([]receptor.DesiredLRPResponse{}, receptorError)
+
+				updateAppParams := app_runner.UpdateAppParams{
+					Name: "test-app",
+				}
+
+				err := appRunner.UpdateApp(updateAppParams)
+				Expect(err).To(MatchError(receptorError))
+			})
+		})
+	})
+
 	Describe("RemoveApp", func() {
 		It("Removes a Docker App", func() {
 			desiredLRPs := []receptor.DesiredLRPResponse{

--- a/ltc/app_runner/command_factory/app_runner_command_factory.go
+++ b/ltc/app_runner/command_factory/app_runner_command_factory.go
@@ -355,7 +355,7 @@ func (factory *AppRunnerCommandFactory) WaitForAppCreation(appName string, pollT
 }
 
 func (factory *AppRunnerCommandFactory) externalPortMappingForApp(externalPort uint16, containerPort uint16) string {
-	return fmt.Sprintf("External TCP Port %d mapped to application port %d", externalPort, containerPort)
+	return fmt.Sprintf("%s:%d\n", factory.Domain, externalPort)
 }
 
 func (factory *AppRunnerCommandFactory) urlForAppName(name string) string {

--- a/ltc/app_runner/command_factory/app_runner_command_factory.go
+++ b/ltc/app_runner/command_factory/app_runner_command_factory.go
@@ -270,7 +270,7 @@ func (factory *AppRunnerCommandFactory) WaitForAppCreation(appName string, pollT
 		for _, route := range routeOverrides {
 			factory.UI.SayLine(colors.Green(factory.urlForAppName(route.HostnamePrefix)))
 		}
-	} else {
+	} else if len(tcpRoutes) == 0 {
 		factory.UI.SayLine(colors.Green(factory.urlForAppName(appName)))
 	}
 }

--- a/ltc/app_runner/fake_app_runner/fake_app_runner.go
+++ b/ltc/app_runner/fake_app_runner/fake_app_runner.go
@@ -43,6 +43,14 @@ type FakeAppRunner struct {
 	updateAppRoutesReturns struct {
 		result1 error
 	}
+	UpdateAppStub        func(updateAppParams app_runner.UpdateAppParams) error
+	updateAppMutex       sync.RWMutex
+	updateAppArgsForCall []struct {
+		updateAppParams app_runner.UpdateAppParams
+	}
+	updateAppReturns struct {
+		result1 error
+	}
 	RemoveAppStub        func(name string) error
 	removeAppMutex       sync.RWMutex
 	removeAppArgsForCall []struct {
@@ -180,6 +188,38 @@ func (fake *FakeAppRunner) UpdateAppRoutesArgsForCall(i int) (string, app_runner
 func (fake *FakeAppRunner) UpdateAppRoutesReturns(result1 error) {
 	fake.UpdateAppRoutesStub = nil
 	fake.updateAppRoutesReturns = struct {
+		result1 error
+	}{result1}
+}
+
+func (fake *FakeAppRunner) UpdateApp(updateAppParams app_runner.UpdateAppParams) error {
+	fake.updateAppMutex.Lock()
+	fake.updateAppArgsForCall = append(fake.updateAppArgsForCall, struct {
+		updateAppParams app_runner.UpdateAppParams
+	}{updateAppParams})
+	fake.updateAppMutex.Unlock()
+	if fake.UpdateAppStub != nil {
+		return fake.UpdateAppStub(updateAppParams)
+	} else {
+		return fake.updateAppReturns.result1
+	}
+}
+
+func (fake *FakeAppRunner) UpdateAppCallCount() int {
+	fake.updateAppMutex.RLock()
+	defer fake.updateAppMutex.RUnlock()
+	return len(fake.updateAppArgsForCall)
+}
+
+func (fake *FakeAppRunner) UpdateAppArgsForCall(i int) app_runner.UpdateAppParams {
+	fake.updateAppMutex.RLock()
+	defer fake.updateAppMutex.RUnlock()
+	return fake.updateAppArgsForCall[i].updateAppParams
+}
+
+func (fake *FakeAppRunner) UpdateAppReturns(result1 error) {
+	fake.UpdateAppStub = nil
+	fake.updateAppReturns = struct {
 		result1 error
 	}{result1}
 }

--- a/ltc/cli_app_factory/app_help.go
+++ b/ltc/cli_app_factory/app_help.go
@@ -95,6 +95,7 @@ func newAppPresenter(app *cli.App) (presenter appPresenter) {
 					presentCommand("remove"),
 					presentCommand("scale"),
 					presentCommand("update-routes"),
+					presentCommand("update"),
 				},
 			},
 		}, {

--- a/ltc/cli_app_factory/cli_app_factory.go
+++ b/ltc/cli_app_factory/cli_app_factory.go
@@ -152,7 +152,7 @@ func cliCommands(ltcConfigRoot string, exitHandler exit_handler.ExitHandler, con
 
 	appExaminer := app_examiner.New(receptorClient, app_examiner.NewNoaaConsumer(noaaConsumer))
 	graphicalVisualizer := graphical.NewGraphicalVisualizer(appExaminer)
-	appExaminerCommandFactory := app_examiner_command_factory.NewAppExaminerCommandFactory(appExaminer, ui, clock, exitHandler, graphicalVisualizer, taskExaminer)
+	appExaminerCommandFactory := app_examiner_command_factory.NewAppExaminerCommandFactory(appExaminer, ui, clock, exitHandler, graphicalVisualizer, taskExaminer, config.Target())
 
 	appRunnerCommandFactoryConfig := app_runner_command_factory.AppRunnerCommandFactoryConfig{
 		AppRunner:           appRunner,

--- a/ltc/cli_app_factory/cli_app_factory.go
+++ b/ltc/cli_app_factory/cli_app_factory.go
@@ -220,6 +220,7 @@ func cliCommands(ltcConfigRoot string, exitHandler exit_handler.ExitHandler, con
 		taskRunnerCommandFactory.MakeCancelTaskCommand(),
 		clusterTestCommandFactory.MakeClusterTestCommand(),
 		appRunnerCommandFactory.MakeUpdateRoutesCommand(),
+		appRunnerCommandFactory.MakeUpdateCommand(),
 		appExaminerCommandFactory.MakeVisualizeCommand(),
 		dropletRunnerCommandFactory.MakeBuildDropletCommand(),
 		dropletRunnerCommandFactory.MakeListDropletsCommand(),

--- a/ltc/cluster_test/cluster_test_runner.go
+++ b/ltc/cluster_test/cluster_test_runner.go
@@ -178,7 +178,7 @@ func defineTheGinkgoTests(runner *clusterTestRunner, timeout time.Duration) {
 				})
 
 				It("should run a docker app exposing tcp routes", func() {
-					runner.createDockerApp(timeout, appName, "cloudfoundry/tcp-sample-receiver", fmt.Sprintf("--tcp-routes=5222:%d", externalPort), fmt.Sprintf("--timeout=%s", timeout.String()))
+					runner.createDockerApp(timeout, appName, "cloudfoundry/tcp-sample-receiver", fmt.Sprintf("--tcp-routes=%d:5222", externalPort), fmt.Sprintf("--timeout=%s", timeout.String()))
 					Eventually(errorCheckForConnection(runner.config.Target(), externalPort), timeout, 1).ShouldNot(HaveOccurred())
 				})
 			})

--- a/ltc/cluster_test/cluster_test_runner.go
+++ b/ltc/cluster_test/cluster_test_runner.go
@@ -179,7 +179,7 @@ func defineTheGinkgoTests(runner *clusterTestRunner, timeout time.Duration) {
 
 				It("should run a docker app exposing tcp routes", func() {
 					runner.createDockerApp(timeout, appName, "cloudfoundry/tcp-sample-receiver", fmt.Sprintf("--tcp-routes=%d:5222", externalPort), fmt.Sprintf("--timeout=%s", timeout.String()))
-					Eventually(errorCheckForConnection(runner.config.Target(), externalPort), timeout, 1).ShouldNot(HaveOccurred())
+					Eventually(errorCheckForConnection(runner.config.Target(), externalPort, "docker-server1"), timeout, 1).ShouldNot(HaveOccurred())
 				})
 			})
 		})
@@ -241,6 +241,34 @@ func defineTheGinkgoTests(runner *clusterTestRunner, timeout time.Duration) {
 
 				Eventually(errorCheckForRoute(appRoute), timeout, .5).ShouldNot(HaveOccurred())
 			})
+
+			Context("droplet with tcp routes", func() {
+
+				It("should build, lists and launches a droplet with tcp routes", func() {
+
+					externalPort := uint16(51000)
+					By("checking out droplet-receiver from github")
+					gitDir := runner.cloneRepo(timeout, "https://github.com/cloudfoundry-incubator/cf-tcp-router-acceptance-tests.git")
+					dropletDir := gitDir + "/assets/tcp-droplet-receiver"
+					defer os.RemoveAll(gitDir)
+
+					By("launching a build task")
+					runner.buildDroplet(timeout, dropletName, "https://github.com/cloudfoundry/go-buildpack.git", dropletDir)
+
+					By("uploading a compiled droplet to the blob store")
+					Eventually(errorCheckURLExists(dropletFolderURL+"/droplet.tgz"), timeout, 1).ShouldNot(HaveOccurred())
+
+					By("listing droplets")
+					runner.listDroplets(timeout, dropletName)
+
+					By("launching the droplet")
+					runner.launchDroplet(timeout, appName, dropletName, fmt.Sprintf("--tcp-routes=%d:3333", externalPort), "--ports=3333")
+
+					Eventually(errorCheckForConnection(runner.config.Target(), externalPort, "droplet_server"), timeout, 1).ShouldNot(HaveOccurred())
+				})
+
+			})
+
 		})
 	})
 }
@@ -277,10 +305,16 @@ func (runner *clusterTestRunner) buildDroplet(timeout time.Duration, dropletName
 	Expect(session.Out).To(gbytes.Say("Submitted build of " + dropletName))
 }
 
-func (runner *clusterTestRunner) launchDroplet(timeout time.Duration, appName, dropletName string) {
+func (runner *clusterTestRunner) launchDroplet(timeout time.Duration, args ...string) {
+	appName := args[0]
+	dropletName := args[1]
+
 	fmt.Fprintln(getStyledWriter("test"), colors.PurpleUnderline(fmt.Sprintf("Launching droplet %s as %s", dropletName, appName)))
 
-	command := runner.command("launch-droplet", appName, dropletName)
+	cmdArgs := make([]string, 0)
+	cmdArgs = append(cmdArgs, "launch-droplet")
+	cmdArgs = append(cmdArgs, args...)
+	command := runner.command(cmdArgs...)
 
 	session, err := gexec.Start(command, getStyledWriter("launch-droplet"), getStyledWriter("launch-droplet"))
 	Expect(err).NotTo(HaveOccurred())
@@ -384,7 +418,7 @@ func getStyledWriter(prefix string) io.Writer {
 	return gexec.NewPrefixedWriter(fmt.Sprintf("[%s] ", colors.Yellow(prefix)), GinkgoWriter)
 }
 
-func errorCheckForConnection(ip string, port uint16) func() error {
+func errorCheckForConnection(ip string, port uint16, serverId string) func() error {
 	fmt.Fprintln(getStyledWriter("test"), "Connection to ", ip, ":", port)
 	return func() error {
 		response, err := makeTcpConnRequest(ip, port, "test")
@@ -393,7 +427,7 @@ func errorCheckForConnection(ip string, port uint16) func() error {
 		}
 		fmt.Fprintln(getStyledWriter("test"), "Received response '", response, "'")
 
-		if !strings.Contains(response, "docker-server1:test") {
+		if !strings.Contains(response, serverId+":test") {
 			return errors.New("Did not get correct response from connection")
 		}
 

--- a/ltc/docker_runner/command_factory/docker_runner_command_factory.go
+++ b/ltc/docker_runner/command_factory/docker_runner_command_factory.go
@@ -112,15 +112,15 @@ func (factory *DockerRunnerCommandFactory) MakeCreateAppCommand() cli.Command {
 		},
 		cli.StringFlag{
 			Name: "http-routes, R",
-			Usage: "Comma separated list of hostnames and ports. Usage: HOST:CONTAINER_PORT[,…].\n\t\t" +
-				"E.g. given —http-routes=foo:8080, requests for foo.SYSTEM_DOMAIN on port 80\n\t\t" +
-				"will be forwarded to container port 8080.",
+			Usage: "Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port. \n\t\t" +
+				"Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. \n\t\t" +
+				"Usage: --http-routes HOST:CONTAINER_PORT[,...].",
 		},
 		cli.StringFlag{
 			Name: "tcp-routes, T",
-			Usage: "Comma separated list of external port and container port. Usage: EXTERNAL_PORT:CONTAINER_PORT[,…].\n\t\t" +
-				"E.g. given —tcp-routes=50000:5222, requests for port 50000\n\t\t" +
-				"will be forwarded to container port 5222.",
+			Usage: "Requests for the provided external port will be forwarded to the associated container port. \n\t\t" +
+				"Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. \n\t\t" +
+				"Usage: --tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]  ",
 		},
 		cli.IntFlag{
 			Name:  "instances, i",
@@ -361,7 +361,7 @@ func (factory *DockerRunnerCommandFactory) createApp(context *cli.Context) {
 	}
 
 	factory.WaitForAppCreation(name, timeoutFlag, instancesFlag,
-		noRoutesFlag, routeOverrides, tcpRoutes)
+		noRoutesFlag, routeOverrides, tcpRoutes, monitorConfig.Port, exposedPorts)
 }
 
 func (factory *DockerRunnerCommandFactory) getExposedPortsFromArgs(portsFlag string, imageMetadata *docker_metadata_fetcher.ImageMetadata) ([]uint16, error) {

--- a/ltc/docker_runner/command_factory/docker_runner_command_factory_test.go
+++ b/ltc/docker_runner/command_factory/docker_runner_command_factory_test.go
@@ -966,8 +966,8 @@ var _ = Describe("CommandFactory", func() {
 			Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("cool-web-app is now running.")))
 			Expect(outputBuffer).To(test_helpers.SayLine("App is reachable at:"))
 
-			Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("External TCP Port 50000 mapped to application port 5222")))
-			Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("External TCP Port 50001 mapped to application port 5223")))
+			Expect(outputBuffer).To(test_helpers.Say(colors.Green(domain + ":50000\n")))
+			Expect(outputBuffer).To(test_helpers.Say(colors.Green(domain + ":50001\n")))
 		})
 	})
 

--- a/ltc/docker_runner/command_factory/docker_runner_command_factory_test.go
+++ b/ltc/docker_runner/command_factory/docker_runner_command_factory_test.go
@@ -86,7 +86,7 @@ var _ = Describe("CommandFactory", func() {
 				"--cpu-weight=57",
 				"--memory-mb=12",
 				"--disk-mb=12",
-				"--routes=3000:route-3000-yay,1111:route-1111-wahoo,1111:route-1111-me-too",
+				"--http-routes=route-3000-yay:3000,route-1111-wahoo:1111,route-1111-me-too:1111",
 				"--working-dir=/applications",
 				"--run-as-root=true",
 				"--instances=22",
@@ -182,14 +182,14 @@ var _ = Describe("CommandFactory", func() {
 				args := []string{
 					"cool-web-app",
 					"superfun/app",
-					"--routes=woo:aahh",
+					"--http-routes=woo:aahh",
 					"--",
 					"/start-me-please",
 				}
 
 				test_helpers.ExecuteCommandWithArgs(createCommand, args)
 
-				Expect(outputBuffer).To(test_helpers.Say(app_runner_command_factory.MalformedRouteErrorMessage))
+				Expect(outputBuffer).To(test_helpers.Say(app_runner_command_factory.InvalidPortErrorMessage))
 				Expect(fakeAppRunner.CreateAppCallCount()).To(Equal(0))
 				Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.InvalidSyntax}))
 			})
@@ -198,7 +198,7 @@ var _ = Describe("CommandFactory", func() {
 				args := []string{
 					"cool-web-app",
 					"superfun/app",
-					"--routes=8888",
+					"--http-routes=8888",
 					"--",
 					"/start-me-please",
 				}
@@ -890,7 +890,7 @@ var _ = Describe("CommandFactory", func() {
 
 				test_helpers.ExecuteCommandWithArgs(createCommand, args)
 
-				Expect(outputBuffer).To(test_helpers.Say(app_runner_command_factory.InvalidRoutePortErrorMessage))
+				Expect(outputBuffer).To(test_helpers.Say(app_runner_command_factory.InvalidPortErrorMessage))
 				Expect(fakeAppRunner.CreateAppCallCount()).To(Equal(0))
 				Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.InvalidSyntax}))
 			})
@@ -915,7 +915,7 @@ var _ = Describe("CommandFactory", func() {
 
 		It("creates a Docker based app with tcp routes as specified in the command via the AppRunner", func() {
 			args := []string{
-				"--tcp-routes=5222:50000,5223:50001",
+				"--tcp-routes=50000:5222,50001:5223",
 				"cool-web-app",
 				"superfun/app:mycooltag",
 				"--",

--- a/ltc/docker_runner/command_factory/docker_runner_command_factory_test.go
+++ b/ltc/docker_runner/command_factory/docker_runner_command_factory_test.go
@@ -230,6 +230,10 @@ var _ = Describe("CommandFactory", func() {
 				Expect(fakeAppRunner.CreateAppCallCount()).To(Equal(1))
 				createAppParams := fakeAppRunner.CreateAppArgsForCall(0)
 				Expect(createAppParams.ExposedPorts).To(Equal([]uint16{8080, 9090}))
+				Expect(outputBuffer).To(test_helpers.Say("App is reachable at:\n"))
+				Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("http://cool-web-app.192.168.11.11.xip.io")))
+				Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("http://cool-web-app-8080.192.168.11.11.xip.io")))
+				Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("http://cool-web-app-9090.192.168.11.11.xip.io")))
 			})
 
 			It("exposes ports from image metadata", func() {
@@ -248,6 +252,11 @@ var _ = Describe("CommandFactory", func() {
 				Expect(outputBuffer).To(test_helpers.SayLine("No port specified, using exposed ports from the image metadata.\n\tExposed Ports: 1200, 2701, 4302"))
 				createAppParams := fakeAppRunner.CreateAppArgsForCall(0)
 				Expect(createAppParams.ExposedPorts).To(Equal([]uint16{1200, 2701, 4302}))
+				Expect(outputBuffer).To(test_helpers.Say("App is reachable at:\n"))
+				Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("http://cool-web-app.192.168.11.11.xip.io")))
+				Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("http://cool-web-app-1200.192.168.11.11.xip.io")))
+				Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("http://cool-web-app-2701.192.168.11.11.xip.io")))
+				Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("http://cool-web-app-4302.192.168.11.11.xip.io")))
 			})
 
 			It("exposes --ports ports when both --ports and EXPOSE metadata exist", func() {
@@ -966,8 +975,8 @@ var _ = Describe("CommandFactory", func() {
 			Expect(outputBuffer).To(test_helpers.SayLine(colors.Green("cool-web-app is now running.")))
 			Expect(outputBuffer).To(test_helpers.SayLine("App is reachable at:"))
 
-			Expect(outputBuffer).To(test_helpers.Say(colors.Green(domain + ":50000\n")))
-			Expect(outputBuffer).To(test_helpers.Say(colors.Green(domain + ":50001\n")))
+			Expect(outputBuffer).To(test_helpers.SayLine(colors.Green(domain + ":50000")))
+			Expect(outputBuffer).To(test_helpers.SayLine(colors.Green(domain + ":50001")))
 		})
 	})
 

--- a/ltc/droplet_runner/command_factory/droplet_runner_command_factory.go
+++ b/ltc/droplet_runner/command_factory/droplet_runner_command_factory.go
@@ -511,7 +511,7 @@ func (factory *DropletRunnerCommandFactory) launchDroplet(context *cli.Context) 
 		return
 	}
 
-	factory.WaitForAppCreation(appName, timeoutFlag, instancesFlag, noRoutesFlag, routeOverrides, tcpRoutes)
+	factory.WaitForAppCreation(appName, timeoutFlag, instancesFlag, noRoutesFlag, routeOverrides, tcpRoutes, monitorConfig.Port, exposedPorts)
 }
 
 func (factory *DropletRunnerCommandFactory) removeDroplet(context *cli.Context) {

--- a/ltc/droplet_runner/command_factory/droplet_runner_command_factory.go
+++ b/ltc/droplet_runner/command_factory/droplet_runner_command_factory.go
@@ -179,15 +179,15 @@ func (factory *DropletRunnerCommandFactory) MakeLaunchDropletCommand() cli.Comma
 		},
 		cli.StringFlag{
 			Name: "http-routes, R",
-			Usage: "Comma separated list of hostnames and ports. Usage: HOST:CONTAINER_PORT[,…].\n\t\t" +
-				"E.g. given —http-routes=foo:8080, requests for foo.SYSTEM_DOMAIN on port 80\n\t\t" +
-				"will be forwarded to container port 8080.",
+			Usage: "Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port. \n\t\t" +
+				"Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. \n\t\t" +
+				"Usage: --http-routes HOST:CONTAINER_PORT[,...].",
 		},
 		cli.StringFlag{
 			Name: "tcp-routes, T",
-			Usage: "Comma separated list of external port and container port. Usage: EXTERNAL_PORT:CONTAINER_PORT[,…].\n\t\t" +
-				"E.g. given —tcp-routes=50000:5222, requests for port 50000\n\t\t" +
-				"will be forwarded to container port 5222.",
+			Usage: "Requests for the provided external port will be forwarded to the associated container port. \n\t\t" +
+				"Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. \n\t\t" +
+				"Usage: --tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]  ",
 		},
 		cli.IntFlag{
 			Name:  "instances, i",

--- a/ltc/droplet_runner/command_factory/droplet_runner_command_factory.go
+++ b/ltc/droplet_runner/command_factory/droplet_runner_command_factory.go
@@ -178,14 +178,16 @@ func (factory *DropletRunnerCommandFactory) MakeLaunchDropletCommand() cli.Comma
 			Value: time.Second,
 		},
 		cli.StringFlag{
-			Name: "routes, R",
-			Usage: "Route mappings to exposed ports as follows:\n\t\t" +
-				"--routes=80:web,8080:api will route web to 80 and api to 8080",
+			Name: "http-routes, R",
+			Usage: "Comma separated list of hostnames and ports. Usage: HOST:CONTAINER_PORT[,…].\n\t\t" +
+				"E.g. given —http-routes=foo:8080, requests for foo.SYSTEM_DOMAIN on port 80\n\t\t" +
+				"will be forwarded to container port 8080.",
 		},
 		cli.StringFlag{
-			Name: "tcp-routes",
-			Usage: "Create mappings between external ports and container ports for TCP traffic as follows:\n\t\t" +
-				"--tcp-routes=5222:50000,6379:50001 will route traffic from the external port 50000 to the container port 5222\n\t\t and external port 50001 to container port 6379",
+			Name: "tcp-routes, T",
+			Usage: "Comma separated list of external port and container port. Usage: EXTERNAL_PORT:CONTAINER_PORT[,…].\n\t\t" +
+				"E.g. given —tcp-routes=50000:5222, requests for port 50000\n\t\t" +
+				"will be forwarded to container port 5222.",
 		},
 		cli.IntFlag{
 			Name:  "instances, i",
@@ -208,12 +210,24 @@ func (factory *DropletRunnerCommandFactory) MakeLaunchDropletCommand() cli.Comma
 	}
 
 	var launchDropletCommand = cli.Command{
-		Name:        "launch-droplet",
-		Aliases:     []string{"ld"},
-		Usage:       "Launches a droplet as an app running on lattice",
-		Description: "ltc launch-droplet APP_NAME DROPLET_NAME",
-		Action:      factory.launchDroplet,
-		Flags:       launchFlags,
+		Name:    "launch-droplet",
+		Aliases: []string{"ld"},
+		Usage:   "Launches a droplet as an app running on lattice",
+		Description: `ltc launch-droplet APP_NAME DROPLET_NAME
+
+   Two http routes are created by default, both routing to container port 8080. E.g. for application myapp:
+     - requests to myapp.SYSTEM_DOMAIN:80 will be routed to container port 8080
+     - requests to myapp-8080.SYSTEM_DOMAIN:80 will be routed to container port 8080
+
+   To configure your own routing:
+     ltc launch-droplet APP_NAME DROPLET_NAME --http-routes HOST:CONTAINER_PORT[,...] --tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]
+
+     Examples:
+       ltc launch-droplet myapp ruby --http-routes=myapp-admin:6000 will route requests received at myapp-admin.SYSTEM_DOMAIN:80 to container port 6000.
+       ltc launch-droplet myapp ruby --tcp-routes=50000:6379 will route requests received at SYSTEM_DOMAIN:50000 to container port 6379.
+`,
+		Action: factory.launchDroplet,
+		Flags:  launchFlags,
 	}
 
 	return launchDropletCommand
@@ -417,7 +431,7 @@ func (factory *DropletRunnerCommandFactory) launchDroplet(context *cli.Context) 
 	portMonitorFlag := context.Int("monitor-port")
 	urlMonitorFlag := context.String("monitor-url")
 	monitorTimeoutFlag := context.Duration("monitor-timeout")
-	routesFlag := context.String("routes")
+	httpRoutesFlag := context.String("http-routes")
 	tcpRoutesFlag := context.String("tcp-routes")
 	noRoutesFlag := context.Bool("no-routes")
 	timeoutFlag := context.Duration("timeout")
@@ -459,7 +473,7 @@ func (factory *DropletRunnerCommandFactory) launchDroplet(context *cli.Context) 
 		return
 	}
 
-	routeOverrides, err := factory.ParseRouteOverrides(routesFlag)
+	routeOverrides, err := factory.ParseRouteOverrides(httpRoutesFlag)
 	if err != nil {
 		factory.UI.SayLine(err.Error())
 		factory.ExitHandler.Exit(exit_codes.InvalidSyntax)

--- a/ltc/droplet_runner/command_factory/droplet_runner_command_factory_test.go
+++ b/ltc/droplet_runner/command_factory/droplet_runner_command_factory_test.go
@@ -695,7 +695,7 @@ var _ = Describe("CommandFactory", func() {
 				test_helpers.ExecuteCommandWithArgs(launchDropletCommand, args)
 
 				Expect(fakeDropletRunner.LaunchDropletCallCount()).To(Equal(0))
-				Expect(outputBuffer).To(test_helpers.Say(app_runner_command_factory.InvalidRoutePortErrorMessage))
+				Expect(outputBuffer).To(test_helpers.Say(app_runner_command_factory.InvalidPortErrorMessage))
 				Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.InvalidSyntax}))
 			})
 
@@ -719,8 +719,8 @@ var _ = Describe("CommandFactory", func() {
 		It("launches the specified droplet with tcp routes", func() {
 			fakeAppExaminer.RunningAppInstancesInfoReturns(1, false, nil)
 			args := []string{
-				"--routes=4444:ninetyninety,9090:fourtyfourfourtyfour",
-				"--tcp-routes=5222:50000,5223:50001",
+				"--http-routes=ninetyninety:4444,fourtyfourfourtyfour:9090",
+				"--tcp-routes=50000:5222,50001:5223",
 				"droppy",
 				"droplet-name",
 				"--",
@@ -769,7 +769,7 @@ var _ = Describe("CommandFactory", func() {
 				"--cpu-weight=57",
 				"--memory-mb=12",
 				"--disk-mb=12",
-				"--routes=4444:ninetyninety,9090:fourtyfourfourtyfour",
+				"--http-routes=ninetyninety:4444,fourtyfourfourtyfour:9090",
 				"--working-dir=/xxx",
 				"--instances=11",
 				"--env=TIMEZONE=CST",
@@ -900,13 +900,13 @@ var _ = Describe("CommandFactory", func() {
 				args := []string{
 					"cool-web-app",
 					"cool-web-droplet",
-					"--routes=woo:aahh",
+					"--http-routes=woo:aahh",
 				}
 
 				test_helpers.ExecuteCommandWithArgs(launchDropletCommand, args)
 
 				Expect(fakeDropletRunner.LaunchDropletCallCount()).To(Equal(0))
-				Expect(outputBuffer).To(test_helpers.Say(app_runner_command_factory.MalformedRouteErrorMessage))
+				Expect(outputBuffer).To(test_helpers.Say(app_runner_command_factory.InvalidPortErrorMessage))
 				Expect(fakeExitHandler.ExitCalledWith).To(Equal([]int{exit_codes.InvalidSyntax}))
 			})
 
@@ -914,7 +914,7 @@ var _ = Describe("CommandFactory", func() {
 				args := []string{
 					"cool-web-app",
 					"cool-web-droplet",
-					"--routes=8888",
+					"--http-routes=8888",
 				}
 
 				test_helpers.ExecuteCommandWithArgs(launchDropletCommand, args)


### PR DESCRIPTION
This PR includes following:
- Changed the tcp-routes syntax to be <external-port>:<container-port> in `ltc create`
- Renamed "routes" flag to "http-routes" in `ltc create`
- Changed the syntax of "http-routes" to be <hostname>:<container-port> in `ltc create`
- Added support to display tcp routes in `ltc list` and `ltc status`
- Added new command `ltc update` to update `--http-routes` and `--tcp-routes`, with same syntax as one in `ltc create`
- Updated messages that get displayed in `ltc create` based on http and tcp routes

This PR completes adding tcp routing functionality in lattice.

(This PR is replacing https://github.com/cloudfoundry-incubator/lattice/pull/179)
