### PR TITLE
Lattice tcp usage updates

### DIFF
--- a/ltc/app_runner/command_factory/app_runner_command_factory.go
+++ b/ltc/app_runner/command_factory/app_runner_command_factory.go
@@ -132,15 +132,11 @@ func (factory *AppRunnerCommandFactory) MakeUpdateCommand() cli.Command {
 		},
 		cli.StringFlag{
 			Name: "http-routes, R",
-			Usage: "Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port.\n\t\t" +
-				"Container ports must be among those specified on create with --ports or with the EXPOSE Docker image directive.\n\t\t" +
-				"Replaces all existing routes. Usage: --http-routes HOST:CONTAINER_PORT[,...]",
+			Usage: "Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port. Container ports must be among those specified on create with --ports or with the EXPOSE Docker image directive. Replaces all existing routes. Usage: --http-routes HOST:CONTAINER_PORT[,...]",
 		},
 		cli.StringFlag{
 			Name: "tcp-routes, T",
-			Usage: "Requests for the external port will be forwarded to the associated container port.\n\t\t" +
-				"Container ports must be among those specified on create with --ports or with the EXPOSE Docker image directive.\n\t\t" +
-				"Replaces all existing routes. Usage: EXTERNAL_PORT:CONTAINER_PORT[,...]",
+			Usage: "Requests for the external port will be forwarded to the associated container port. Container ports must be among those specified on create with --ports or with the EXPOSE Docker image directive. Replaces all existing routes. Usage: EXTERNAL_PORT:CONTAINER_PORT[,...]",
 		},
 	}
 	var updateCommand = cli.Command{

--- a/ltc/docker_runner/command_factory/docker_runner_command_factory.go
+++ b/ltc/docker_runner/command_factory/docker_runner_command_factory.go
@@ -112,15 +112,11 @@ func (factory *DockerRunnerCommandFactory) MakeCreateAppCommand() cli.Command {
 		},
 		cli.StringFlag{
 			Name: "http-routes, R",
-			Usage: "Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port. \n\t\t" +
-				"Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. \n\t\t" +
-				"Usage: --http-routes HOST:CONTAINER_PORT[,...].",
+			Usage: "Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port. Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. Usage: --http-routes HOST:CONTAINER_PORT[,...].",
 		},
 		cli.StringFlag{
 			Name: "tcp-routes, T",
-			Usage: "Requests for the provided external port will be forwarded to the associated container port. \n\t\t" +
-				"Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. \n\t\t" +
-				"Usage: --tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]  ",
+			Usage: "Requests for the provided external port will be forwarded to the associated container port. Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. Usage: --tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]  ",
 		},
 		cli.IntFlag{
 			Name:  "instances, i",

--- a/ltc/droplet_runner/command_factory/droplet_runner_command_factory.go
+++ b/ltc/droplet_runner/command_factory/droplet_runner_command_factory.go
@@ -179,15 +179,11 @@ func (factory *DropletRunnerCommandFactory) MakeLaunchDropletCommand() cli.Comma
 		},
 		cli.StringFlag{
 			Name: "http-routes, R",
-			Usage: "Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port. \n\t\t" +
-				"Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. \n\t\t" +
-				"Usage: --http-routes HOST:CONTAINER_PORT[,...].",
+			Usage: "Requests for HOST.SYSTEM_DOMAIN on port 80 will be forwarded to the associated container port. Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. Usage: --http-routes HOST:CONTAINER_PORT[,...].",
 		},
 		cli.StringFlag{
 			Name: "tcp-routes, T",
-			Usage: "Requests for the provided external port will be forwarded to the associated container port. \n\t\t" +
-				"Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. \n\t\t" +
-				"Usage: --tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]  ",
+			Usage: "Requests for the provided external port will be forwarded to the associated container port. Container ports must be among those specified with --ports or with the EXPOSE Docker image directive. Usage: --tcp-routes EXTERNAL_PORT:CONTAINER_PORT[,...]  ",
 		},
 		cli.IntFlag{
 			Name:  "instances, i",


### PR DESCRIPTION
This PR includes:
- Updates to formatting of help/usage for `http-routes` and `tcp-routes` in `ltc create`, `ltc update` and `ltc launch-droplet`.
- Addition of `PORTS` environment variable to enable lattice-app to listen on multiple ports exposed through `ports` flag (for story #101547830)

Regards,
@atulkc and @fordaz 
