### PR TITLE
[ltc vz -g] Fix cell name

### DIFF
--- a/ltc/app_examiner/command_factory/graphical/graphical_visualizer.go
+++ b/ltc/app_examiner/command_factory/graphical/graphical_visualizer.go
@@ -3,8 +3,6 @@ package graphical
 import (
 	"errors"
 	"fmt"
-	"strconv"
-	"strings"
 	"time"
 
 	"github.com/cloudfoundry-incubator/lattice/ltc/app_examiner"
@@ -146,7 +144,6 @@ func (gv *graphicalVisualizer) getProgressBars(bg *termui.MBarChart) error {
 	var barStringList []string
 
 	var barLabel string
-	var cellIndex int
 	maxTotal := -1
 
 	cells, err := gv.appExaminer.ListCells()
@@ -154,7 +151,7 @@ func (gv *graphicalVisualizer) getProgressBars(bg *termui.MBarChart) error {
 		return err
 	}
 
-	for i, cell := range cells {
+	for _, cell := range cells {
 
 		if cell.Missing {
 			barLabel = fmt.Sprintf("Missing")
@@ -165,16 +162,10 @@ func (gv *graphicalVisualizer) getProgressBars(bg *termui.MBarChart) error {
 			barIntList[1] = append(barIntList[1], 0)
 		} else {
 
-			cellNames := strings.Split(cell.CellID, "-")
-			if len(cellNames) == 3 { //The cell name is usually of the form lattice-cell-[CellNumber]
-				cellIndex, _ = strconv.Atoi(cellNames[2])
-			} else { //Otherwise print the index of this cell
-				cellIndex = i + 1
-			}
 			total := cell.RunningInstances + cell.ClaimedInstances
 			barIntList[0] = append(barIntList[0], cell.RunningInstances)
 			barIntList[1] = append(barIntList[1], cell.ClaimedInstances)
-			barLabel = fmt.Sprintf("cell-%d", cellIndex)
+			barLabel = cell.CellID
 			if total > maxTotal {
 				maxTotal = total
 			}


### PR DESCRIPTION
[#93577238]
This fixes the lattice cell name as `ltc vz --graphical` use to assume that the cell name is of the format `lattice-cell-01`  now the default cell name is of the format `cell-01`.

This also kept going into the else block so should probably print wrong cell name in a mult-cell setup

```
cellNames := strings.Split(cell.CellID, "-")
if len(cellNames) == 3 { //The cell name is usually of the form lattice-cell-[CellNumber]
    cellIndex, _ = strconv.Atoi(cellNames[2])
} else { //Otherwise print the index of this cell
    cellIndex = i + 1
}
```

Question: In a multi-cell setup is there a standard way to name a cell? when i tried to simulate a multi cell to test vz this was the output as 'cell's are sorted alphabetically. 

```
cell-1: ••••••••••••
cell-10: ••••••••••••••••••••••••••••••
cell-11: ••••••••••••••••••••••••••••••••
cell-12: ••••••••••••••••••••••••••••••••••
cell-13: ••••••••••••••••••••••••••••••••••••
cell-14: ••••••••••••••••••••••••••••••••••••••
cell-15: ••••••••••••••••••••••••••••••••••••••••
cell-16: ••••••••••••••••••••••••••••••••••••••••••
cell-17: ••••••••••••••••••••••••••••••••••••••••••••
cell-18: ••••••••••••••••••••••••••••••••••••••••••••••
cell-19: ••••••••••••••••••••••••••••••••••••••••••••••••
cell-2: ••••••••••••••
cell-20: ••••••••••••••••••••••••••••••••••••••••••••••••••
cell-3: ••••••••••••••••
cell-4: ••••••••••••••••••
cell-5: ••••••••••••••••••••
cell-6: ••••••••••••••••••••••
cell-7: ••••••••••••••••••••••••
cell-8: ••••••••••••••••••••••••••
cell-9: ••••••••••••••••••••••••••••
```

Now `ltc vz -g` should behave in the same way. 
