### PR TITLE
Bump cf-routing-release and include routing-api as part of lattice

### DIFF
--- a/vagrant/manifest.yml
+++ b/vagrant/manifest.yml
@@ -65,6 +65,8 @@ jobs:
     release: cf-lattice
   - name: nats
     release: cf-lattice
+  - name: routing-api
+    release: cf-routing
 
   # Cell:
   - name: rep
@@ -168,10 +170,12 @@ properties:
     enable_routing_api: false
     router_configurer:
       gorouter_secret: router-secret
+      routing_api_auth_disabled: true
     tcp_emitter:
       diego_api_url: http://placeholder-username:placeholder-password@receptor.service.cf.internal:8888
       gorouter_secret: router-secret
       debug_addr: 0.0.0.0:17019
+      routing_api_auth_disabled: true
       bbs:
         api_location: bbs.service.cf.internal:8889
         ca_cert: ""
@@ -202,6 +206,7 @@ properties:
         gorouter: {}
         receptor: {}
         router_configurer: {}
+        routing-api: {}
       servers:
         lan: [placeholder-ip]
     require_ssl: false
@@ -218,11 +223,15 @@ properties:
     shared_secret: loggregator-secret
   doppler_endpoint:
     shared_secret: loggregator-secret
+  routing-api:
+    auth_disabled: true
   uaa:
     url: ""
     clients:
       doppler:
         secret: doppler-secret
+    jwt:
+      verification_key: ""
   cc:
     srv_api_uri: ""
 


### PR DESCRIPTION
This PR is to add routing-api as part of lattice brain and bump cf-routing-release. 
1. New cf-routing-release uses routing-api and bbs. 
2. routing-api is pulled from cf-routing-release
3. lattice manifest modified to deploy routing-api and set its properties appropriately

Note that due to changes in cf-routing-release `ltc` was modified to pass `router_group_guid` as part of tcp routes. Those changes are submitted as part of PR.

Regards,
@fordaz and @atulkc 
(CF Routing team)
