### PR TITLE
Remove nonexistent link from contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,8 +18,6 @@ Here are some ways *you* can contribute:
 * by closing [issues](https://github.com/cloudfoundry-incubator/lattice/issues)
 * by reviewing patches
 
-Also see the [Development Readme](development/README.md)
-
 ## Submitting an Issue
 We use the [GitHub issue tracker](https://github.com/cloudfoundry-incubator/lattice/issues) to track bugs and features.
 Before submitting a bug report or feature request, check to make sure it hasn't already been submitted.


### PR DESCRIPTION
`development/README.md` does not exist in the repository, and it doesn't appear that it ever has, so I assume this was copypasta from another project. If there's a document that this is supposed to refer to I'll update the link instead if someone points out to me what it is.

I'm not sure if there's a `[ci skip]` type of commit message annotation for Concourse, if there is and it should be used I can update this commit.

Also, while I'm here, is there a public repo for the http://lattice.cf/ site? I saw a few small typos/grammar fixes I was planning to submit when I actually looked at the contributing guide in the first place :smile:  If there's a repo or a `gh-pages` branch or the like somewhere, it wasn't obvious to me.
